### PR TITLE
Fix schedules silently ignoring spec changes; add delete API

### DIFF
--- a/client.go
+++ b/client.go
@@ -271,6 +271,18 @@ func (c *Client) CreateFlowSchedule(ctx context.Context, flowName, cronSpec stri
 	return CreateFlowSchedule(ctx, c.Conn, flowName, cronSpec, opts...)
 }
 
+// DeleteTaskSchedule removes the cron schedule for a task.
+// It reports whether a schedule existed; deleting a missing schedule is a no-op.
+func (c *Client) DeleteTaskSchedule(ctx context.Context, taskName string) (bool, error) {
+	return DeleteTaskSchedule(ctx, c.Conn, taskName)
+}
+
+// DeleteFlowSchedule removes the cron schedule for a flow.
+// It reports whether a schedule existed; deleting a missing schedule is a no-op.
+func (c *Client) DeleteFlowSchedule(ctx context.Context, flowName string) (bool, error) {
+	return DeleteFlowSchedule(ctx, c.Conn, flowName)
+}
+
 // ListTaskSchedules returns all task schedules ordered by next_run_at.
 func (c *Client) ListTaskSchedules(ctx context.Context) ([]*TaskScheduleInfo, error) {
 	return ListTaskSchedules(ctx, c.Conn)

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -337,16 +337,26 @@ These are the functions most app code and external clients care about.
 **Scheduling setup**
 
 ### `cb_create_task_schedule`
-- **What it does**: Create or replace a cron schedule for a task with static JSON input and catch-up policy.
+- **What it does**: Create or replace a cron schedule for a task with static JSON input and catch-up policy. If a schedule already exists for the task it is upserted: `cron_spec`, `input`, and `catch_up` are updated. `next_run_at` is only recomputed when `cron_spec` actually changes, so repeat calls with the same spec preserve any catch-up backlog.
 - **Inputs**: `cb_create_task_schedule(task_name text, cron_spec text, input jsonb DEFAULT '{}'::jsonb, catch_up text DEFAULT 'one')`
 - **Returns**: `RETURNS void`
 - **Catch-up policies**: `'skip'` (skip all missed ticks), `'one'` (enqueue one catch-up, default), `'all'` (replay every missed tick)
 
 ### `cb_create_flow_schedule`
-- **What it does**: Create or replace a cron schedule for a flow with static JSON input and catch-up policy.
+- **What it does**: Create or replace a cron schedule for a flow with static JSON input and catch-up policy. If a schedule already exists for the flow it is upserted: `cron_spec`, `input`, and `catch_up` are updated. `next_run_at` is only recomputed when `cron_spec` actually changes, so repeat calls with the same spec preserve any catch-up backlog.
 - **Inputs**: `cb_create_flow_schedule(flow_name text, cron_spec text, input jsonb DEFAULT '{}'::jsonb, catch_up text DEFAULT 'one')`
 - **Returns**: `RETURNS void`
 - **Catch-up policies**: `'skip'` (skip all missed ticks), `'one'` (enqueue one catch-up, default), `'all'` (replay every missed tick)
+
+### `cb_delete_task_schedule`
+- **What it does**: Remove the cron schedule for a task. Returns `true` if a schedule existed, `false` otherwise (deleting a missing schedule is a no-op).
+- **Inputs**: `cb_delete_task_schedule(task_name text)`
+- **Returns**: `RETURNS boolean`
+
+### `cb_delete_flow_schedule`
+- **What it does**: Remove the cron schedule for a flow. Returns `true` if a schedule existed, `false` otherwise (deleting a missing schedule is a no-op).
+- **Inputs**: `cb_delete_flow_schedule(flow_name text)`
+- **Returns**: `RETURNS boolean`
 
 **Maintenance**
 

--- a/flow.go
+++ b/flow.go
@@ -1899,6 +1899,14 @@ func CreateFlowSchedule(ctx context.Context, conn Conn, flowName, cronSpec strin
 	return nil
 }
 
+// DeleteFlowSchedule removes the cron schedule for a flow.
+// It reports whether a schedule existed; deleting a missing schedule is a no-op.
+func DeleteFlowSchedule(ctx context.Context, conn Conn, flowName string) (bool, error) {
+	existed := false
+	err := conn.QueryRow(ctx, `SELECT cb_delete_flow_schedule($1);`, flowName).Scan(&existed)
+	return existed, err
+}
+
 // ListFlowSchedules returns all flow schedules ordered by next_run_at.
 func ListFlowSchedules(ctx context.Context, conn Conn) ([]*FlowScheduleInfo, error) {
 	q := `SELECT flow_name, cron_spec, next_run_at, last_run_at, last_enqueued_at, enabled, catch_up, created_at, updated_at

--- a/migrate.go
+++ b/migrate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-const SchemaVersion = 1
+const SchemaVersion = 2
 const gooseVersionTable = "cb_goose_db_version"
 
 //go:embed migrations/*.sql

--- a/migrations/00002_schedule_management.sql
+++ b/migrations/00002_schedule_management.sql
@@ -1,0 +1,214 @@
+-- +goose up
+
+-- cb_create_task_schedule / cb_create_flow_schedule previously returned early
+-- when a schedule already existed, silently dropping cron_spec/input/catch_up
+-- changes on subsequent calls. Bring them in line with cb_create_flow by
+-- upserting on conflict. next_run_at is only recomputed when the cron spec
+-- actually changes, so repeat calls with the same spec don't discard a
+-- catch-up backlog (which deliberately keeps next_run_at in the past).
+--
+-- Also add cb_delete_task_schedule / cb_delete_flow_schedule so callers can
+-- remove a schedule explicitly. Schedules are poll-based (no NOTIFY), so unlike
+-- cb_delete_queue/task/flow these emit no event: the next poll simply skips the
+-- removed row.
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_create_task_schedule(task_name text, cron_spec text, input jsonb DEFAULT '{}'::jsonb, catch_up text DEFAULT 'one')
+RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtext('cb_task_schedules:' || cb_create_task_schedule.task_name));
+
+    INSERT INTO cb_task_schedules (
+        task_name,
+        cron_spec,
+        next_run_at,
+        input,
+        catch_up,
+        enabled,
+        updated_at
+    )
+    VALUES (
+        cb_create_task_schedule.task_name,
+        cb_create_task_schedule.cron_spec,
+        cb_next_cron_tick(cb_create_task_schedule.cron_spec, now()),
+        cb_create_task_schedule.input,
+        cb_create_task_schedule.catch_up,
+        true,
+        now()
+    )
+    ON CONFLICT ON CONSTRAINT cb_task_schedules_task_name_key DO UPDATE
+    SET
+        cron_spec = EXCLUDED.cron_spec,
+        input = EXCLUDED.input,
+        catch_up = EXCLUDED.catch_up,
+        next_run_at = CASE
+            WHEN cb_task_schedules.cron_spec IS DISTINCT FROM EXCLUDED.cron_spec
+            THEN cb_next_cron_tick(EXCLUDED.cron_spec, now())
+            ELSE cb_task_schedules.next_run_at
+        END,
+        updated_at = now();
+END;
+$$;
+-- +goose statementend
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_create_flow_schedule(flow_name text, cron_spec text, input jsonb DEFAULT '{}'::jsonb, catch_up text DEFAULT 'one')
+RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtext('cb_flow_schedules:' || cb_create_flow_schedule.flow_name));
+
+    INSERT INTO cb_flow_schedules (
+        flow_name,
+        cron_spec,
+        next_run_at,
+        input,
+        catch_up,
+        enabled,
+        updated_at
+    )
+    VALUES (
+        cb_create_flow_schedule.flow_name,
+        cb_create_flow_schedule.cron_spec,
+        cb_next_cron_tick(cb_create_flow_schedule.cron_spec, now()),
+        cb_create_flow_schedule.input,
+        cb_create_flow_schedule.catch_up,
+        true,
+        now()
+    )
+    ON CONFLICT ON CONSTRAINT cb_flow_schedules_flow_name_key DO UPDATE
+    SET
+        cron_spec = EXCLUDED.cron_spec,
+        input = EXCLUDED.input,
+        catch_up = EXCLUDED.catch_up,
+        next_run_at = CASE
+            WHEN cb_flow_schedules.cron_spec IS DISTINCT FROM EXCLUDED.cron_spec
+            THEN cb_next_cron_tick(EXCLUDED.cron_spec, now())
+            ELSE cb_flow_schedules.next_run_at
+        END,
+        updated_at = now();
+END;
+$$;
+-- +goose statementend
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_delete_task_schedule(task_name text)
+RETURNS boolean
+LANGUAGE plpgsql AS $$
+DECLARE
+    _res boolean;
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtext('cb_task_schedules:' || cb_delete_task_schedule.task_name));
+
+    DELETE FROM cb_task_schedules s
+    WHERE s.task_name = cb_delete_task_schedule.task_name
+    RETURNING true
+    INTO _res;
+
+    RETURN coalesce(_res, false);
+END;
+$$;
+-- +goose statementend
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_delete_flow_schedule(flow_name text)
+RETURNS boolean
+LANGUAGE plpgsql AS $$
+DECLARE
+    _res boolean;
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtext('cb_flow_schedules:' || cb_delete_flow_schedule.flow_name));
+
+    DELETE FROM cb_flow_schedules s
+    WHERE s.flow_name = cb_delete_flow_schedule.flow_name
+    RETURNING true
+    INTO _res;
+
+    RETURN coalesce(_res, false);
+END;
+$$;
+-- +goose statementend
+
+-- +goose down
+
+DROP FUNCTION IF EXISTS cb_delete_flow_schedule(text);
+DROP FUNCTION IF EXISTS cb_delete_task_schedule(text);
+
+-- Restore the original early-return behaviour for the create functions.
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_create_task_schedule(task_name text, cron_spec text, input jsonb DEFAULT '{}'::jsonb, catch_up text DEFAULT 'one')
+RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtext('cb_task_schedules:' || cb_create_task_schedule.task_name));
+
+    -- Return early if schedule already exists
+    IF EXISTS (
+        SELECT 1
+        FROM cb_task_schedules s
+        WHERE s.task_name = cb_create_task_schedule.task_name
+    ) THEN
+        RETURN;
+    END IF;
+
+    INSERT INTO cb_task_schedules (
+        task_name,
+        cron_spec,
+        next_run_at,
+        input,
+        catch_up,
+        enabled,
+        updated_at
+    )
+    VALUES (
+        cb_create_task_schedule.task_name,
+        cb_create_task_schedule.cron_spec,
+        cb_next_cron_tick(cb_create_task_schedule.cron_spec, now()),
+        cb_create_task_schedule.input,
+        cb_create_task_schedule.catch_up,
+        true,
+        now()
+    );
+END;
+$$;
+-- +goose statementend
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_create_flow_schedule(flow_name text, cron_spec text, input jsonb DEFAULT '{}'::jsonb, catch_up text DEFAULT 'one')
+RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtext('cb_flow_schedules:' || cb_create_flow_schedule.flow_name));
+
+    -- Return early if schedule already exists
+    IF EXISTS (
+        SELECT 1
+        FROM cb_flow_schedules s
+        WHERE s.flow_name = cb_create_flow_schedule.flow_name
+    ) THEN
+        RETURN;
+    END IF;
+
+    INSERT INTO cb_flow_schedules (
+        flow_name,
+        cron_spec,
+        next_run_at,
+        input,
+        catch_up,
+        enabled,
+        updated_at
+    )
+    VALUES (
+        cb_create_flow_schedule.flow_name,
+        cb_create_flow_schedule.cron_spec,
+        cb_next_cron_tick(cb_create_flow_schedule.cron_spec, now()),
+        cb_create_flow_schedule.input,
+        cb_create_flow_schedule.catch_up,
+        true,
+        now()
+    );
+END;
+$$;
+-- +goose statementend

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -311,6 +311,194 @@ func TestSchedulerEnqueueRollback(t *testing.T) {
 	}
 }
 
+// TestSchedulerScheduleUpsert verifies that re-creating an existing schedule
+// applies a changed cron spec (instead of silently ignoring it), while a
+// re-create with the same spec preserves next_run_at. See issue #34.
+func TestSchedulerScheduleUpsert(t *testing.T) {
+	client := getTestClient(t)
+	suffix := fmt.Sprintf("_%d", time.Now().UnixNano())
+	taskName := "test_upsert_task" + suffix
+	flowName := "test_upsert_flow" + suffix
+
+	findTaskSchedule := func(name string) *TaskScheduleInfo {
+		schedules, err := client.ListTaskSchedules(t.Context())
+		if err != nil {
+			t.Fatalf("ListTaskSchedules failed: %v", err)
+		}
+		for _, s := range schedules {
+			if s.TaskName == name {
+				return s
+			}
+		}
+		t.Fatalf("no task schedule found for %q", name)
+		return nil
+	}
+
+	task := NewTask(taskName).Do(func(ctx context.Context, in string) (string, error) {
+		return "done", nil
+	})
+	if err := CreateTask(t.Context(), client.Conn, task); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create with an hourly spec (the "stale fallback" from the bug report).
+	if err := client.CreateTaskSchedule(t.Context(), taskName, "0 */1 * * *"); err != nil {
+		t.Fatalf("CreateTaskSchedule failed: %v", err)
+	}
+	initial := findTaskSchedule(taskName)
+	if initial.CronSpec != "0 */1 * * *" {
+		t.Fatalf("expected initial cron_spec %q, got %q", "0 */1 * * *", initial.CronSpec)
+	}
+
+	// Re-create with the corrected spec — must be applied, not ignored.
+	if err := client.CreateTaskSchedule(t.Context(), taskName, "*/1 * * * *", WithCatchUpAll()); err != nil {
+		t.Fatalf("CreateTaskSchedule (update) failed: %v", err)
+	}
+	updated := findTaskSchedule(taskName)
+	if updated.CronSpec != "*/1 * * * *" {
+		t.Fatalf("expected updated cron_spec %q, got %q (spec change silently ignored)", "*/1 * * * *", updated.CronSpec)
+	}
+	if updated.CatchUp != "all" {
+		t.Fatalf("expected catch_up to update to %q, got %q", "all", updated.CatchUp)
+	}
+	if !updated.NextRunAt.Before(initial.NextRunAt) {
+		t.Fatalf("expected next_run_at to be recomputed earlier after spec change: initial=%s updated=%s", initial.NextRunAt, updated.NextRunAt)
+	}
+
+	// Re-create with the same spec — next_run_at must be preserved.
+	if err := client.CreateTaskSchedule(t.Context(), taskName, "*/1 * * * *", WithCatchUpAll()); err != nil {
+		t.Fatalf("CreateTaskSchedule (same spec) failed: %v", err)
+	}
+	unchanged := findTaskSchedule(taskName)
+	if !unchanged.NextRunAt.Equal(updated.NextRunAt) {
+		t.Fatalf("expected next_run_at preserved on same-spec re-create: before=%s after=%s", updated.NextRunAt, unchanged.NextRunAt)
+	}
+
+	// Flows behave the same way.
+	flow := NewFlow(flowName)
+	flow.AddStep(NewStep("s1").Do(func(ctx context.Context, in int) (int, error) {
+		return in, nil
+	}))
+	if err := CreateFlow(t.Context(), client.Conn, flow); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.CreateFlowSchedule(t.Context(), flowName, "0 */1 * * *"); err != nil {
+		t.Fatalf("CreateFlowSchedule failed: %v", err)
+	}
+	if err := client.CreateFlowSchedule(t.Context(), flowName, "*/1 * * * *"); err != nil {
+		t.Fatalf("CreateFlowSchedule (update) failed: %v", err)
+	}
+
+	flowSchedules, err := client.ListFlowSchedules(t.Context())
+	if err != nil {
+		t.Fatalf("ListFlowSchedules failed: %v", err)
+	}
+	var fs *FlowScheduleInfo
+	for _, s := range flowSchedules {
+		if s.FlowName == flowName {
+			fs = s
+		}
+	}
+	if fs == nil {
+		t.Fatalf("no flow schedule found for %q", flowName)
+	}
+	if fs.CronSpec != "*/1 * * * *" {
+		t.Fatalf("expected updated flow cron_spec %q, got %q (spec change silently ignored)", "*/1 * * * *", fs.CronSpec)
+	}
+}
+
+// TestSchedulerScheduleDelete verifies schedules can be removed, that delete
+// reports whether a schedule existed, and that deleting a missing schedule is
+// a no-op. See issue #34.
+func TestSchedulerScheduleDelete(t *testing.T) {
+	client := getTestClient(t)
+	suffix := fmt.Sprintf("_%d", time.Now().UnixNano())
+	taskName := "test_delete_task" + suffix
+	flowName := "test_delete_flow" + suffix
+
+	hasTaskSchedule := func(name string) bool {
+		schedules, err := client.ListTaskSchedules(t.Context())
+		if err != nil {
+			t.Fatalf("ListTaskSchedules failed: %v", err)
+		}
+		for _, s := range schedules {
+			if s.TaskName == name {
+				return true
+			}
+		}
+		return false
+	}
+	hasFlowSchedule := func(name string) bool {
+		schedules, err := client.ListFlowSchedules(t.Context())
+		if err != nil {
+			t.Fatalf("ListFlowSchedules failed: %v", err)
+		}
+		for _, s := range schedules {
+			if s.FlowName == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Deleting a non-existent schedule is a no-op that reports false.
+	existed, err := client.DeleteTaskSchedule(t.Context(), taskName)
+	if err != nil {
+		t.Fatalf("DeleteTaskSchedule (missing) failed: %v", err)
+	}
+	if existed {
+		t.Fatalf("expected DeleteTaskSchedule to report false for missing schedule")
+	}
+
+	task := NewTask(taskName).Do(func(ctx context.Context, in string) (string, error) {
+		return "done", nil
+	})
+	if err := CreateTask(t.Context(), client.Conn, task); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CreateTaskSchedule(t.Context(), taskName, "@hourly"); err != nil {
+		t.Fatalf("CreateTaskSchedule failed: %v", err)
+	}
+	if !hasTaskSchedule(taskName) {
+		t.Fatalf("expected task schedule to exist after create")
+	}
+
+	existed, err = client.DeleteTaskSchedule(t.Context(), taskName)
+	if err != nil {
+		t.Fatalf("DeleteTaskSchedule failed: %v", err)
+	}
+	if !existed {
+		t.Fatalf("expected DeleteTaskSchedule to report true for existing schedule")
+	}
+	if hasTaskSchedule(taskName) {
+		t.Fatalf("expected task schedule to be gone after delete")
+	}
+
+	// Flows behave the same way.
+	flow := NewFlow(flowName)
+	flow.AddStep(NewStep("s1").Do(func(ctx context.Context, in int) (int, error) {
+		return in, nil
+	}))
+	if err := CreateFlow(t.Context(), client.Conn, flow); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CreateFlowSchedule(t.Context(), flowName, "@daily"); err != nil {
+		t.Fatalf("CreateFlowSchedule failed: %v", err)
+	}
+
+	existed, err = client.DeleteFlowSchedule(t.Context(), flowName)
+	if err != nil {
+		t.Fatalf("DeleteFlowSchedule failed: %v", err)
+	}
+	if !existed {
+		t.Fatalf("expected DeleteFlowSchedule to report true for existing schedule")
+	}
+	if hasFlowSchedule(flowName) {
+		t.Fatalf("expected flow schedule to be gone after delete")
+	}
+}
+
 // TestSchedulerConcurrentWorkers verifies that multiple workers fairly distribute
 // due schedules without creating duplicates or starving any worker.
 // This tests the core distributed scheduling guarantee: exactly one execution

--- a/task.go
+++ b/task.go
@@ -632,6 +632,14 @@ func CreateTaskSchedule(ctx context.Context, conn Conn, taskName, cronSpec strin
 	return nil
 }
 
+// DeleteTaskSchedule removes the cron schedule for a task.
+// It reports whether a schedule existed; deleting a missing schedule is a no-op.
+func DeleteTaskSchedule(ctx context.Context, conn Conn, taskName string) (bool, error) {
+	existed := false
+	err := conn.QueryRow(ctx, `SELECT cb_delete_task_schedule($1);`, taskName).Scan(&existed)
+	return existed, err
+}
+
 // ListTaskSchedules returns all task schedules ordered by next_run_at.
 func ListTaskSchedules(ctx context.Context, conn Conn) ([]*TaskScheduleInfo, error) {
 	q := `SELECT task_name, cron_spec, next_run_at, last_run_at, last_enqueued_at, enabled, catch_up, created_at, updated_at


### PR DESCRIPTION
Fixes #34.

## Problem
`cb_create_task_schedule` / `cb_create_flow_schedule` returned early when a schedule already existed, so a changed cron spec on a subsequent call was silently dropped — the stale spec persisted indefinitely.

## Changes
- **Upsert on re-create** — both functions now `INSERT ... ON CONFLICT ... DO UPDATE` (matching `cb_create_flow`), updating `cron_spec`/`input`/`catch_up`. `next_run_at` is only recomputed when the cron spec actually changes, so repeat calls with the same spec preserve any catch-up backlog.
- **Delete API** — adds `cb_delete_task_schedule` / `cb_delete_flow_schedule` plus the matching `DeleteTaskSchedule` / `DeleteFlowSchedule` Go + client methods, rounding out the create/list/delete lifecycle. No NOTIFY (schedules are poll-based).
- Migration `00002_schedule_management.sql`, `SchemaVersion` bumped to 2, docs updated.

## Tests
- `TestSchedulerScheduleUpsert` — pins the regression (changed spec is applied; same-spec re-create preserves `next_run_at`), task + flow.
- `TestSchedulerScheduleDelete` — delete-missing is a no-op returning false; create→delete returns true and removes the row.

Full suite green.