### PR TITLE
Add durable per-identity notification inbox (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A PostgreSQL-powered message queue and task execution engine. Catbird brings rel
 - **Resiliency baked in**: retries, backoff, optional circuit breakers.
 - **Operational UX**: web dashboard and tui for runs, queues, and workers.
 - **Optional real-time layer**: opt-in pub/sub with SSE support for pushing events to browsers.
+- **Durable notifications**: a per-identity inbox with a cursor and seen-tracking, so clients reliably catch up on missed notifications at their own pace.
 
 <p align="center">
   <img src="assets/screenshots/dashboard-flows.png" alt="Flow Visualization" width="800" />
@@ -872,6 +873,65 @@ task := catbird.NewTask("process-order").Do(func(ctx context.Context, input Orde
 })
 ```
 
+## Durable Notifications
+
+A per-identity durable inbox. Where Wire is ephemeral push — miss the moment
+(navigating, offline, asleep) and the notification is gone — the inbox is a store the
+client catches up against on its own schedule. It is a separate primitive with **no
+dependency on Wire**: delete Wire and the inbox still does its whole job.
+
+The inbox is a mailbox keyed by `identity`. Each notification has a monotonic `id`
+(the cursor) and a `seen` marker, so "replay everything since I last looked" is just
+*read the unseen rows after my cursor, then ack the cursor*.
+
+```go
+// Append to an identity's inbox; returns the new id (the cursor value)
+id, err := catbird.NotifyDurable(ctx, conn, "user-123", "import.done", "Your import finished")
+
+// Read unseen, still-relevant notifications after the client's last cursor
+ns, err := catbird.UnseenNotifications(ctx, conn, "user-123", afterID, 50)
+for _, n := range ns {
+    fmt.Println(n.ID, n.Topic, n.Message)
+}
+
+// Ack the cursor: mark everything up to an id seen (returns rows marked)
+marked, err := catbird.MarkSeen(ctx, conn, "user-123", ns[len(ns)-1].ID)
+```
+
+**Relevance window (`ExpiresAt`).** A notification is a *perishable pointer to a durable
+fact* — the underlying result lives permanently elsewhere (e.g. a task row); the
+notification is only the prompt to look. Set `ExpiresAt` to bound how long it is worth
+delivering: once it passes, the row drops out of `UnseenNotifications` and `cb_gc`
+deletes it. Leave it zero and the notification **waits until seen** (cleared by
+`MarkSeen`, not by a timer) — the right choice for "action required" items.
+
+```go
+// Perishable toast: gone after an hour whether seen or not
+catbird.NotifyDurable(ctx, conn, "user-123", "batch.done", "Batch finished",
+    catbird.NotifyDurableOpts{ExpiresAt: time.Now().Add(time.Hour)})
+
+// Collapse: a newer notification with the same CollapseKey marks prior unseen ones
+// seen, so only the latest stays live (FCM collapse-key semantics — keep newest,
+// the deliberate opposite of the queue's keep-oldest ConcurrencyKey)
+catbird.NotifyDurable(ctx, conn, "user-123", "import.progress", "100%",
+    catbird.NotifyDurableOpts{CollapseKey: "import-42"})
+```
+
+Reads return **unseen *and* still-relevant** rows — never "everything since the cursor"
+— so an identity offline for a day is not flooded with stale toasts. Retention folds
+into the core `cb_gc` sweep (see [Data Retention](#data-retention)).
+
+**Pairing with Wire (optional).** Durability (is it stored?) and transport (push vs
+poll) are independent. If you also run Wire, push a *content-free ping* and let the
+client re-pull from its cursor — the store stays the single source of truth and the
+cursor dedups, so a client that is both connected and polling never shows a
+notification twice:
+
+```go
+catbird.NotifyDurable(ctx, conn, userID, topic, msg, opts) // the real message, stored
+wire.Notify(ctx, "user."+userID, "")                       // empty ping → client re-pulls
+```
+
 ## Naming Rules
 
 - **Queue, task, flow, and step names**: Lowercase letters, digits, and underscores only (`a-z`, `0-9`, `_`). Max 58 characters. Step names must be unique within a flow. Reserved step names: `input`, `signal`.
@@ -967,7 +1027,12 @@ _ = gcInfo.ExpiredQueuesDeleted
 _ = gcInfo.StaleWorkersDeleted
 _ = gcInfo.TaskRunsPurged
 _ = gcInfo.FlowRunsPurged
+_ = gcInfo.ExpiredNotificationsDeleted
 ```
+
+Durable notifications past their `ExpiresAt` are deleted by the same `cb_gc()` sweep.
+Because GC runs from the worker heartbeat, a deployment that runs Wire but no worker
+must call `client.GC(ctx)` on its own schedule, or expired notifications accumulate.
 
 ```go
 task := catbird.NewTask("send-email").

--- a/catbird.go
+++ b/catbird.go
@@ -62,14 +62,15 @@ type Conn interface {
 
 // GCInfo is the garbage collection report returned by cb_gc().
 type GCInfo struct {
-	ExpiredQueuesDeleted   int `json:"expired_queues_deleted"`
-	ExpiredMessagesDeleted int `json:"expired_messages_deleted"`
-	ExpiredTaskRuns        int `json:"expired_task_runs"`
-	ExpiredFlowRuns        int `json:"expired_flow_runs"`
-	StaleWorkersDeleted    int `json:"stale_workers_deleted"`
-	StaleWireNodesDeleted  int `json:"stale_wire_nodes_deleted"`
-	TaskRunsPurged         int `json:"task_runs_purged"`
-	FlowRunsPurged         int `json:"flow_runs_purged"`
+	ExpiredQueuesDeleted        int `json:"expired_queues_deleted"`
+	ExpiredMessagesDeleted      int `json:"expired_messages_deleted"`
+	ExpiredTaskRuns             int `json:"expired_task_runs"`
+	ExpiredFlowRuns             int `json:"expired_flow_runs"`
+	StaleWorkersDeleted         int `json:"stale_workers_deleted"`
+	StaleWireNodesDeleted       int `json:"stale_wire_nodes_deleted"`
+	ExpiredNotificationsDeleted int `json:"expired_notifications_deleted"`
+	TaskRunsPurged              int `json:"task_runs_purged"`
+	FlowRunsPurged              int `json:"flow_runs_purged"`
 }
 
 // GC runs garbage collection to clean up expired queues and stale workers.

--- a/catbird_test.go
+++ b/catbird_test.go
@@ -88,6 +88,7 @@ func verifyMigrationsApplied(ctx context.Context, db *sql.DB) error {
 		12: {"cb_next_cron_tick"},
 		13: {"cb_create_task_schedule", "cb_create_flow_schedule", "cb_advance_task_schedule", "cb_advance_flow_schedule", "cb_execute_due_task_schedules", "cb_execute_due_flow_schedules"},
 		16: {"cb_notify"},
+		3:  {"cb_notify_durable", "cb_mark_seen"},
 	}
 
 	for version, functions := range requiredFunctions {

--- a/client.go
+++ b/client.go
@@ -241,6 +241,23 @@ func (c *Client) Notify(ctx context.Context, topic, message string, opts ...Noti
 	return Notify(ctx, c.Conn, topic, message, opts...)
 }
 
+// NotifyDurable appends a durable notification to identity's inbox and returns its id.
+func (c *Client) NotifyDurable(ctx context.Context, identity, topic, message string, opts ...NotifyDurableOpts) (int64, error) {
+	return NotifyDurable(ctx, c.Conn, identity, topic, message, opts...)
+}
+
+// UnseenNotifications returns an identity's unseen and still-relevant notifications
+// with id greater than afterID, ordered by id, limited to limit rows.
+func (c *Client) UnseenNotifications(ctx context.Context, identity string, afterID int64, limit int) ([]Notification, error) {
+	return UnseenNotifications(ctx, c.Conn, identity, afterID, limit)
+}
+
+// MarkSeen acks the cursor: marks all of identity's unseen notifications with id
+// less than or equal to upToID as seen, and returns the number of rows marked.
+func (c *Client) MarkSeen(ctx context.Context, identity string, upToID int64) (int64, error) {
+	return MarkSeen(ctx, c.Conn, identity, upToID)
+}
+
 // Reader continuously reads messages from a queue and processes them.
 // Blocks until ctx is cancelled.
 func (c *Client) Reader(ctx context.Context, queueName string, quantity int, hideFor time.Duration, handler ReaderHandler, opts ...ReadPollOpts) error {

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -167,6 +167,49 @@ ORDER BY finished_at, id
 LIMIT $batch_size;
 ```
 
+### Durable notifications
+
+```sql
+-- Append a durable notification to an identity's inbox; returns the new id (cursor)
+SELECT cb_notify_durable(
+	identity => 'user-123',
+	topic => 'import.done',
+	message => 'Your import finished'
+);
+
+-- Collapse progress updates: a newer message with the same collapse_key marks
+-- prior unseen ones seen, so only the latest stays live (FCM collapse_key semantics)
+SELECT cb_notify_durable(
+	identity => 'user-123',
+	topic => 'import.progress',
+	message => '100%',
+	collapse_key => 'import-42',
+	expires_at => now() + interval '1 hour'
+);
+
+-- Read an identity's unseen, still-relevant notifications after a cursor
+SELECT id, topic, message, created_at
+FROM cb_notifications
+WHERE identity = 'user-123'
+	AND id > 0                       -- the client's last-seen cursor
+	AND seen_at IS NULL
+	AND (expires_at IS NULL OR expires_at > now())
+ORDER BY id
+LIMIT 50;
+
+-- Ack the cursor: mark everything up to an id seen; returns rows marked
+SELECT cb_mark_seen(
+	identity => 'user-123',
+	up_to_id => 42
+);
+```
+
+Retention (physically dropping rows past their `expires_at`) folds into the core
+`cb_gc` sweep, which runs on worker heartbeat. A deployment that runs Wire but no
+worker therefore performs no GC — it must call `cb_gc()` / `Client.GC()` on its own
+schedule, or notifications accumulate. The unseen read already hides stale rows, so
+this is a storage concern, not a correctness one.
+
 ## Public SQL API
 
 These are the functions most app code and external clients care about.
@@ -361,11 +404,11 @@ These are the functions most app code and external clients care about.
 **Maintenance**
 
 ### `cb_gc`
-- **What it does**: Garbage collection: deletes expired queues and messages, transitions expired task/flow runs to `'expired'` status, cleans stale workers and wire nodes, purges old terminal runs.
+- **What it does**: Garbage collection: deletes expired queues and messages, transitions expired task/flow runs to `'expired'` status, cleans stale workers and wire nodes, deletes durable notifications past their relevance window, purges old terminal runs.
 - **Inputs**: `cb_gc()`
 - **Returns**: `RETURNS jsonb`
 - **Returned JSON shape**:
-	- `{ "expired_queues_deleted": int, "expired_messages_deleted": int, "expired_task_runs": int, "expired_flow_runs": int, "stale_workers_deleted": int, "stale_wire_nodes_deleted": int, "task_runs_purged": int, "flow_runs_purged": int }`
+	- `{ "expired_queues_deleted": int, "expired_messages_deleted": int, "expired_task_runs": int, "expired_flow_runs": int, "stale_workers_deleted": int, "stale_wire_nodes_deleted": int, "expired_notifications_deleted": int, "task_runs_purged": int, "flow_runs_purged": int }`
 
 ### `cb_clear_task_runs`
 - **What it does**: Delete all task runs regardless of status. In-flight work will be lost.
@@ -393,6 +436,20 @@ These are the functions most app code and external clients care about.
 - **What it does**: Send a notification via pg NOTIFY on the schema-qualified cb_wire channel.
 - **Inputs**: `cb_notify(topic text, data text DEFAULT NULL, node_id uuid DEFAULT NULL)`
 - **Returns**: `RETURNS void`
+
+**Durable notifications (per-identity inbox)**
+
+### `cb_notify_durable`
+- **What it does**: Append a durable notification to an identity's inbox and return the new row id (the monotonic cursor). When `collapse_key` is set, prior unseen rows with the same `(identity, collapse_key)` are first marked seen (write-time keep-newest collapse, the FCM `collapse_key` semantics — the deliberate opposite of the queue's keep-oldest `concurrency_key`), so the new row is the only live one for that subject. `expires_at` is the relevance window and the GC drop trigger.
+- **Inputs**: `cb_notify_durable(identity text, topic text, message text DEFAULT NULL, collapse_key text DEFAULT NULL, expires_at timestamptz DEFAULT NULL)`
+- **Returns**: `RETURNS bigint`
+
+### `cb_mark_seen`
+- **What it does**: Cursor ack: mark an identity's unseen notifications with `id <= up_to_id` as seen. Returns the number of rows marked.
+- **Inputs**: `cb_mark_seen(identity text, up_to_id bigint)`
+- **Returns**: `RETURNS bigint`
+
+The unseen read is a plain parameterized `SELECT` against `cb_notifications` (unseen **and** still-relevant: `seen_at IS NULL AND (expires_at IS NULL OR expires_at > now())`), not a function — see the usage example above.
 
 ## Internal / runtime SQL API
 

--- a/migrate.go
+++ b/migrate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-const SchemaVersion = 2
+const SchemaVersion = 3
 const gooseVersionTable = "cb_goose_db_version"
 
 //go:embed migrations/*.sql

--- a/migrations/00003_notifications.sql
+++ b/migrations/00003_notifications.sql
@@ -1,0 +1,357 @@
+-- +goose up
+
+-- Durable, per-identity notification inbox. A mailbox keyed by identity with a
+-- monotonic cursor (id) and a seen marker. The store is the cursor authority;
+-- transports (poll, SSE push) are dumb readers. "Replay since I last looked" is
+-- just WHERE id > cursor. Logged (durability is the point), deliberately separate
+-- from Wire's UNLOGGED tables so a future Wire extraction never touches it.
+
+CREATE TABLE IF NOT EXISTS cb_notifications (
+    id                bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,  -- the cursor
+    identity          text        NOT NULL,
+    topic             text        NOT NULL,
+    collapse_key      text,                  -- optional; a newer row collapses prior unseen rows with the same (identity, collapse_key)
+    message           text,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    seen_at           timestamptz,
+    expires_at        timestamptz,           -- relevance window; also the GC drop trigger
+    CONSTRAINT cb_expires_at_is_valid CHECK (expires_at IS NULL OR expires_at > created_at)
+);
+
+CREATE INDEX IF NOT EXISTS cb_notifications_unseen_idx
+    ON cb_notifications (identity, id) WHERE seen_at IS NULL;                        -- hot poll path
+CREATE INDEX IF NOT EXISTS cb_notifications_expires_at_idx
+    ON cb_notifications (expires_at) WHERE expires_at IS NOT NULL;                   -- gc sweep
+CREATE INDEX IF NOT EXISTS cb_notifications_collapse_key_idx
+    ON cb_notifications (identity, collapse_key)
+    WHERE collapse_key IS NOT NULL AND seen_at IS NULL;                              -- collapse lookup
+
+-- +goose statementbegin
+-- cb_notify_durable: append a durable notification to an identity's inbox.
+-- Returns the new row id (the cursor value).
+-- When collapse_key is set, prior unseen rows with the same (identity, collapse_key)
+-- are first marked seen (write-time collapse, the FCM collapse_key semantics: a newer
+-- message with the same key replaces the older undelivered one), so the new row is the
+-- only live one for that subject. Note this is keep-newest, the deliberate opposite of
+-- the queue's keep-oldest concurrency_key.
+CREATE OR REPLACE FUNCTION cb_notify_durable(
+    identity text,
+    topic text,
+    message text DEFAULT NULL,
+    collapse_key text DEFAULT NULL,
+    expires_at timestamptz DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql AS $$
+DECLARE
+    _id bigint;
+BEGIN
+    IF cb_notify_durable.collapse_key IS NOT NULL THEN
+        UPDATE cb_notifications
+        SET seen_at = now()
+        WHERE cb_notifications.identity = cb_notify_durable.identity
+          AND cb_notifications.collapse_key = cb_notify_durable.collapse_key
+          AND cb_notifications.seen_at IS NULL;
+    END IF;
+
+    INSERT INTO cb_notifications (identity, topic, collapse_key, message, expires_at)
+    VALUES (
+        cb_notify_durable.identity,
+        cb_notify_durable.topic,
+        cb_notify_durable.collapse_key,
+        cb_notify_durable.message,
+        cb_notify_durable.expires_at
+    )
+    RETURNING id INTO _id;
+
+    RETURN _id;
+END;
+$$;
+-- +goose statementend
+
+-- +goose statementbegin
+-- cb_mark_seen: cursor ack. Marks unseen rows with id <= up_to_id as seen for this
+-- identity. Returns the number of rows marked. Seen-tracking always flows through this
+-- cursor regardless of transport.
+CREATE OR REPLACE FUNCTION cb_mark_seen(identity text, up_to_id bigint)
+RETURNS bigint
+LANGUAGE plpgsql AS $$
+DECLARE
+    _marked bigint;
+BEGIN
+    UPDATE cb_notifications
+    SET seen_at = now()
+    WHERE cb_notifications.identity = cb_mark_seen.identity
+      AND cb_notifications.id <= cb_mark_seen.up_to_id
+      AND cb_notifications.seen_at IS NULL;
+
+    GET DIAGNOSTICS _marked = ROW_COUNT;
+
+    RETURN _marked;
+END;
+$$;
+-- +goose statementend
+
+-- +goose statementbegin
+-- Fold durable-notification retention into the core cb_gc sweep (no new background
+-- loop): drop notifications whose relevance window has passed. For notifications
+-- relevance and retention coincide, so a single expires_at does double duty.
+CREATE OR REPLACE FUNCTION cb_gc()
+RETURNS jsonb
+LANGUAGE plpgsql AS $$
+DECLARE
+    _rec record;
+    _expired_queues_deleted int := 0;
+    _expired_messages_deleted int := 0;
+    _expired_task_runs int := 0;
+    _expired_flow_runs int := 0;
+    _stale_workers_deleted int := 0;
+    _stale_wire_nodes_deleted int := 0;
+    _expired_notifications_deleted int := 0;
+    _task_runs_purged int := 0;
+    _flow_runs_purged int := 0;
+    _purged int;
+    _purged_id bigint;
+    _purged_worker_id uuid;
+BEGIN
+    -- Delete queues whose expiry has passed
+    FOR _rec IN
+        SELECT name
+        FROM cb_queues
+        WHERE expires_at IS NOT NULL AND expires_at <= now()
+    LOOP
+        IF cb_delete_queue(_rec.name) THEN
+            _expired_queues_deleted := _expired_queues_deleted + 1;
+        END IF;
+    END LOOP;
+
+    -- Delete expired messages from all queues
+    FOR _rec IN
+        SELECT name FROM cb_queues
+    LOOP
+        EXECUTE format('DELETE FROM %I WHERE expires_at IS NOT NULL AND expires_at <= now()', _cb_table_name(_rec.name, 'q'));
+        GET DIAGNOSTICS _purged = ROW_COUNT;
+        _expired_messages_deleted := _expired_messages_deleted + _purged;
+    END LOOP;
+
+    -- Expire task runs past their expires_at
+    FOR _rec IN
+        SELECT name FROM cb_tasks
+    LOOP
+        FOR _purged_id IN
+            EXECUTE format(
+                'UPDATE %I SET status = ''expired'', expired_at = now()
+                WHERE status IN (''queued'', ''started'')
+                  AND expires_at IS NOT NULL AND expires_at <= now()
+                RETURNING id',
+                _cb_table_name(_rec.name, 't')
+            )
+        LOOP
+            PERFORM _cb_notify(topic => 'catbird.task.expired', message => jsonb_build_object('task', _rec.name, 'run_id', _purged_id)::text);
+            _expired_task_runs := _expired_task_runs + 1;
+        END LOOP;
+    END LOOP;
+
+    -- Expire flow runs past their expires_at
+    FOR _rec IN
+        SELECT name FROM cb_flows
+    LOOP
+        FOR _purged_id IN
+            EXECUTE format(
+                'UPDATE %I SET status = ''expired'', expired_at = now()
+                WHERE status IN (''started'', ''canceling'')
+                  AND expires_at IS NOT NULL AND expires_at <= now()
+                RETURNING id',
+                _cb_table_name(_rec.name, 'f')
+            )
+        LOOP
+            PERFORM _cb_notify(topic => 'catbird.flow.expired', message => jsonb_build_object('flow', _rec.name, 'run_id', _purged_id)::text);
+            _expired_flow_runs := _expired_flow_runs + 1;
+        END LOOP;
+    END LOOP;
+
+    -- Delete workers with no heartbeat for more than 5 minutes
+    FOR _purged_worker_id IN
+        DELETE FROM cb_workers
+        WHERE last_heartbeat_at < now() - INTERVAL '5 minutes'
+        RETURNING id
+    LOOP
+        PERFORM _cb_notify(topic => 'catbird.worker.stopped', message => jsonb_build_object('worker_id', _purged_worker_id)::text);
+        _stale_workers_deleted := _stale_workers_deleted + 1;
+    END LOOP;
+
+    -- Delete Wire nodes with no heartbeat for more than 15 seconds
+    DELETE FROM cb_wire_nodes
+    WHERE last_heartbeat_at < now() - INTERVAL '15 seconds';
+    GET DIAGNOSTICS _stale_wire_nodes_deleted = ROW_COUNT;
+
+    -- Delete durable notifications whose relevance window has passed
+    DELETE FROM cb_notifications
+    WHERE expires_at IS NOT NULL AND expires_at <= now();
+    GET DIAGNOSTICS _expired_notifications_deleted = ROW_COUNT;
+
+    FOR _rec IN
+        SELECT name, retention_period
+        FROM cb_tasks
+        WHERE retention_period IS NOT NULL
+    LOOP
+        _purged := cb_purge_task_runs(_rec.name, _rec.retention_period);
+        _task_runs_purged := _task_runs_purged + _purged;
+    END LOOP;
+
+    FOR _rec IN
+        SELECT name, retention_period
+        FROM cb_flows
+        WHERE retention_period IS NOT NULL
+    LOOP
+        _purged := cb_purge_flow_runs(_rec.name, _rec.retention_period);
+        _flow_runs_purged := _flow_runs_purged + _purged;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'expired_queues_deleted', _expired_queues_deleted,
+        'expired_messages_deleted', _expired_messages_deleted,
+        'expired_task_runs', _expired_task_runs,
+        'expired_flow_runs', _expired_flow_runs,
+        'stale_workers_deleted', _stale_workers_deleted,
+        'stale_wire_nodes_deleted', _stale_wire_nodes_deleted,
+        'expired_notifications_deleted', _expired_notifications_deleted,
+        'task_runs_purged', _task_runs_purged,
+        'flow_runs_purged', _flow_runs_purged
+    );
+END;
+$$;
+-- +goose statementend
+
+-- +goose down
+
+DROP FUNCTION IF EXISTS cb_mark_seen(text, bigint);
+DROP FUNCTION IF EXISTS cb_notify_durable(text, text, text, text, timestamptz);
+
+-- Restore cb_gc without the durable-notifications retention sweep.
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_gc()
+RETURNS jsonb
+LANGUAGE plpgsql AS $$
+DECLARE
+    _rec record;
+    _expired_queues_deleted int := 0;
+    _expired_messages_deleted int := 0;
+    _expired_task_runs int := 0;
+    _expired_flow_runs int := 0;
+    _stale_workers_deleted int := 0;
+    _stale_wire_nodes_deleted int := 0;
+    _task_runs_purged int := 0;
+    _flow_runs_purged int := 0;
+    _purged int;
+    _purged_id bigint;
+    _purged_worker_id uuid;
+BEGIN
+    -- Delete queues whose expiry has passed
+    FOR _rec IN
+        SELECT name
+        FROM cb_queues
+        WHERE expires_at IS NOT NULL AND expires_at <= now()
+    LOOP
+        IF cb_delete_queue(_rec.name) THEN
+            _expired_queues_deleted := _expired_queues_deleted + 1;
+        END IF;
+    END LOOP;
+
+    -- Delete expired messages from all queues
+    FOR _rec IN
+        SELECT name FROM cb_queues
+    LOOP
+        EXECUTE format('DELETE FROM %I WHERE expires_at IS NOT NULL AND expires_at <= now()', _cb_table_name(_rec.name, 'q'));
+        GET DIAGNOSTICS _purged = ROW_COUNT;
+        _expired_messages_deleted := _expired_messages_deleted + _purged;
+    END LOOP;
+
+    -- Expire task runs past their expires_at
+    FOR _rec IN
+        SELECT name FROM cb_tasks
+    LOOP
+        FOR _purged_id IN
+            EXECUTE format(
+                'UPDATE %I SET status = ''expired'', expired_at = now()
+                WHERE status IN (''queued'', ''started'')
+                  AND expires_at IS NOT NULL AND expires_at <= now()
+                RETURNING id',
+                _cb_table_name(_rec.name, 't')
+            )
+        LOOP
+            PERFORM _cb_notify(topic => 'catbird.task.expired', message => jsonb_build_object('task', _rec.name, 'run_id', _purged_id)::text);
+            _expired_task_runs := _expired_task_runs + 1;
+        END LOOP;
+    END LOOP;
+
+    -- Expire flow runs past their expires_at
+    FOR _rec IN
+        SELECT name FROM cb_flows
+    LOOP
+        FOR _purged_id IN
+            EXECUTE format(
+                'UPDATE %I SET status = ''expired'', expired_at = now()
+                WHERE status IN (''started'', ''canceling'')
+                  AND expires_at IS NOT NULL AND expires_at <= now()
+                RETURNING id',
+                _cb_table_name(_rec.name, 'f')
+            )
+        LOOP
+            PERFORM _cb_notify(topic => 'catbird.flow.expired', message => jsonb_build_object('flow', _rec.name, 'run_id', _purged_id)::text);
+            _expired_flow_runs := _expired_flow_runs + 1;
+        END LOOP;
+    END LOOP;
+
+    -- Delete workers with no heartbeat for more than 5 minutes
+    FOR _purged_worker_id IN
+        DELETE FROM cb_workers
+        WHERE last_heartbeat_at < now() - INTERVAL '5 minutes'
+        RETURNING id
+    LOOP
+        PERFORM _cb_notify(topic => 'catbird.worker.stopped', message => jsonb_build_object('worker_id', _purged_worker_id)::text);
+        _stale_workers_deleted := _stale_workers_deleted + 1;
+    END LOOP;
+
+    -- Delete Wire nodes with no heartbeat for more than 15 seconds
+    DELETE FROM cb_wire_nodes
+    WHERE last_heartbeat_at < now() - INTERVAL '15 seconds';
+    GET DIAGNOSTICS _stale_wire_nodes_deleted = ROW_COUNT;
+
+    FOR _rec IN
+        SELECT name, retention_period
+        FROM cb_tasks
+        WHERE retention_period IS NOT NULL
+    LOOP
+        _purged := cb_purge_task_runs(_rec.name, _rec.retention_period);
+        _task_runs_purged := _task_runs_purged + _purged;
+    END LOOP;
+
+    FOR _rec IN
+        SELECT name, retention_period
+        FROM cb_flows
+        WHERE retention_period IS NOT NULL
+    LOOP
+        _purged := cb_purge_flow_runs(_rec.name, _rec.retention_period);
+        _flow_runs_purged := _flow_runs_purged + _purged;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'expired_queues_deleted', _expired_queues_deleted,
+        'expired_messages_deleted', _expired_messages_deleted,
+        'expired_task_runs', _expired_task_runs,
+        'expired_flow_runs', _expired_flow_runs,
+        'stale_workers_deleted', _stale_workers_deleted,
+        'stale_wire_nodes_deleted', _stale_wire_nodes_deleted,
+        'task_runs_purged', _task_runs_purged,
+        'flow_runs_purged', _flow_runs_purged
+    );
+END;
+$$;
+-- +goose statementend
+
+DROP INDEX IF EXISTS cb_notifications_collapse_key_idx;
+DROP INDEX IF EXISTS cb_notifications_expires_at_idx;
+DROP INDEX IF EXISTS cb_notifications_unseen_idx;
+DROP TABLE IF EXISTS cb_notifications;

--- a/notifications.go
+++ b/notifications.go
@@ -1,0 +1,145 @@
+package catbird
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Notification is a single durable notification in an identity's inbox.
+// It is a perishable pointer to a durable fact: the underlying result lives
+// permanently elsewhere (e.g. a task row); the notification is only the prompt
+// to look, so it may go stale.
+type Notification struct {
+	ID          int64     `json:"id"` // monotonic cursor
+	Identity    string    `json:"identity"`
+	Topic       string    `json:"topic"`
+	CollapseKey string    `json:"collapse_key,omitempty"` // empty if none
+	Message     string    `json:"message,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	SeenAt      time.Time `json:"seen_at,omitzero"`    // zero if unseen
+	ExpiresAt   time.Time `json:"expires_at,omitzero"` // zero if none
+}
+
+// NotifyDurableOpts configures a durable notification.
+//
+// ExpiresAt is the relevance window (and the GC drop trigger). When zero, the
+// notification has no time expiry: it waits in the inbox until seen (or until
+// collapsed by a newer notification with the same CollapseKey).
+//
+// CollapseKey, when set, collapses prior unseen notifications with the same
+// (identity, collapse_key) — the FCM collapse-key semantics (keep newest).
+type NotifyDurableOpts struct {
+	ExpiresAt   time.Time
+	CollapseKey string
+}
+
+// NotifyDurable appends a durable notification to identity's inbox and returns
+// its id (the cursor value). Unlike the ephemeral Notify, this is stored so the
+// client can catch up against it on its own schedule.
+//
+// When opts.ExpiresAt is set, it is the relevance window: the notification stops
+// being returned by UnseenNotifications once it passes, and GC drops the row. When
+// zero, the notification waits until seen.
+//
+// When opts.CollapseKey is set, prior unseen notifications with the same
+// (identity, collapse_key) are marked seen first (keep-newest collapse), so the
+// new row is the only live one for that subject.
+func NotifyDurable(ctx context.Context, conn Conn, identity, topic, message string, opts ...NotifyDurableOpts) (int64, error) {
+	var resolved NotifyDurableOpts
+	if len(opts) > 0 {
+		resolved = opts[0]
+	}
+
+	q := `SELECT cb_notify_durable(identity => $1, topic => $2, message => $3, collapse_key => $4, expires_at => $5);`
+
+	var id int64
+	err := conn.QueryRow(ctx, q,
+		identity, topic, ptrOrNil(message), ptrOrNil(resolved.CollapseKey), ptrOrNil(resolved.ExpiresAt),
+	).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// UnseenNotifications returns an identity's unseen and still-relevant
+// notifications with id greater than afterID, ordered by id (the cursor),
+// limited to limit rows. Pass afterID 0 to start from the beginning.
+//
+// Stale notifications (past their expires_at) are filtered out: the read never
+// returns "everything since the cursor", so a client that was offline for a
+// while is not flooded with obsolete prompts.
+func UnseenNotifications(ctx context.Context, conn Conn, identity string, afterID int64, limit int) ([]Notification, error) {
+	q := `
+		SELECT id, identity, topic, collapse_key, message, created_at, seen_at, expires_at
+		FROM cb_notifications
+		WHERE identity = $1
+		  AND id > $2
+		  AND seen_at IS NULL
+		  AND (expires_at IS NULL OR expires_at > now())
+		ORDER BY id
+		LIMIT $3;`
+
+	rows, err := conn.Query(ctx, q, identity, afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, scanCollectibleNotification)
+}
+
+// MarkSeen acks the cursor: it marks all of identity's unseen notifications with
+// id less than or equal to upToID as seen, and returns the number of rows marked.
+// Seen-tracking always flows through this cursor, regardless of transport.
+func MarkSeen(ctx context.Context, conn Conn, identity string, upToID int64) (int64, error) {
+	q := `SELECT cb_mark_seen(identity => $1, up_to_id => $2);`
+
+	var marked int64
+	err := conn.QueryRow(ctx, q, identity, upToID).Scan(&marked)
+	if err != nil {
+		return 0, err
+	}
+	return marked, nil
+}
+
+func scanCollectibleNotification(row pgx.CollectableRow) (Notification, error) {
+	return scanNotification(row)
+}
+
+func scanNotification(row pgx.Row) (Notification, error) {
+	rec := Notification{}
+
+	var collapseKey *string
+	var message *string
+	var seenAt *time.Time
+	var expiresAt *time.Time
+
+	if err := row.Scan(
+		&rec.ID,
+		&rec.Identity,
+		&rec.Topic,
+		&collapseKey,
+		&message,
+		&rec.CreatedAt,
+		&seenAt,
+		&expiresAt,
+	); err != nil {
+		return rec, err
+	}
+
+	if collapseKey != nil {
+		rec.CollapseKey = *collapseKey
+	}
+	if message != nil {
+		rec.Message = *message
+	}
+	if seenAt != nil {
+		rec.SeenAt = *seenAt
+	}
+	if expiresAt != nil {
+		rec.ExpiresAt = *expiresAt
+	}
+
+	return rec, nil
+}

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -1,0 +1,338 @@
+package catbird
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestNotifyDurableAndUnseen verifies a basic append → unseen read round-trip:
+// fields are persisted, rows come back in cursor order, and inboxes are isolated
+// per identity.
+func TestNotifyDurableAndUnseen(t *testing.T) {
+	client := getTestClient(t)
+	ctx := t.Context()
+	conn := client.Conn
+
+	alice := "TestNotifyDurableAndUnseen-alice"
+	bob := "TestNotifyDurableAndUnseen-bob"
+
+	id1, err := NotifyDurable(ctx, conn, alice, "import.started", "started")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := NotifyDurable(ctx, conn, alice, "import.done", "done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id2 <= id1 {
+		t.Fatalf("expected monotonic ids, got %d then %d", id1, id2)
+	}
+
+	// Bob's notification must not leak into Alice's inbox.
+	if _, err := NotifyDurable(ctx, conn, bob, "other", "nope"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := UnseenNotifications(ctx, conn, alice, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 unseen for alice, got %d", len(got))
+	}
+	if got[0].ID != id1 || got[1].ID != id2 {
+		t.Fatalf("expected cursor order [%d %d], got [%d %d]", id1, id2, got[0].ID, got[1].ID)
+	}
+	if got[0].Topic != "import.started" || got[0].Message != "started" {
+		t.Fatalf("unexpected first row: %+v", got[0])
+	}
+	if got[0].Identity != alice {
+		t.Fatalf("expected identity %q, got %q", alice, got[0].Identity)
+	}
+	if !got[0].SeenAt.IsZero() {
+		t.Fatalf("expected unseen row to have zero SeenAt, got %v", got[0].SeenAt)
+	}
+}
+
+// TestUnseenNotificationsPaging verifies cursor paging: afterID advances through
+// the inbox and limit bounds the page size.
+func TestUnseenNotificationsPaging(t *testing.T) {
+	client := getTestClient(t)
+	ctx := t.Context()
+	conn := client.Conn
+
+	identity := "TestUnseenNotificationsPaging"
+	var ids []int64
+	for i := 0; i < 5; i++ {
+		id, err := NotifyDurable(ctx, conn, identity, "evt", fmt.Sprintf("msg-%d", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+
+	// First page of 2.
+	page1, err := UnseenNotifications(ctx, conn, identity, 0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page1) != 2 || page1[0].ID != ids[0] || page1[1].ID != ids[1] {
+		t.Fatalf("unexpected first page: %+v", page1)
+	}
+
+	// Second page resumes after the last id of the first page.
+	cursor := page1[len(page1)-1].ID
+	page2, err := UnseenNotifications(ctx, conn, identity, cursor, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2) != 2 || page2[0].ID != ids[2] || page2[1].ID != ids[3] {
+		t.Fatalf("unexpected second page: %+v", page2)
+	}
+
+	// Final page has the remaining single row.
+	cursor = page2[len(page2)-1].ID
+	page3, err := UnseenNotifications(ctx, conn, identity, cursor, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page3) != 1 || page3[0].ID != ids[4] {
+		t.Fatalf("unexpected third page: %+v", page3)
+	}
+}
+
+// TestMarkSeen verifies the cursor ack: marking through a mid-inbox id leaves
+// only later rows unseen and reports the number of rows marked.
+func TestMarkSeen(t *testing.T) {
+	client := getTestClient(t)
+	ctx := t.Context()
+	conn := client.Conn
+
+	identity := "TestMarkSeen"
+	var ids []int64
+	for i := 0; i < 4; i++ {
+		id, err := NotifyDurable(ctx, conn, identity, "evt", fmt.Sprintf("msg-%d", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+
+	// Mark seen through the second notification.
+	marked, err := MarkSeen(ctx, conn, identity, ids[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if marked != 2 {
+		t.Fatalf("expected 2 rows marked, got %d", marked)
+	}
+
+	got, err := UnseenNotifications(ctx, conn, identity, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].ID != ids[2] || got[1].ID != ids[3] {
+		t.Fatalf("expected only ids[2..3] unseen, got %+v", got)
+	}
+
+	// Re-acking the same cursor is a no-op (rows already seen).
+	marked, err = MarkSeen(ctx, conn, identity, ids[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if marked != 0 {
+		t.Fatalf("expected 0 rows marked on re-ack, got %d", marked)
+	}
+}
+
+// TestNotifyDurableCollapse verifies write-time keep-newest collapse: a newer
+// notification with the same (identity, collapse_key) supersedes prior unseen
+// ones, leaving a single live row carrying the freshest message.
+func TestNotifyDurableCollapse(t *testing.T) {
+	client := getTestClient(t)
+	ctx := t.Context()
+	conn := client.Conn
+
+	identity := "TestNotifyDurableCollapse"
+	key := "import-42"
+
+	if _, err := NotifyDurable(ctx, conn, identity, "import.progress", "50%", NotifyDurableOpts{CollapseKey: key}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NotifyDurable(ctx, conn, identity, "import.progress", "80%", NotifyDurableOpts{CollapseKey: key}); err != nil {
+		t.Fatal(err)
+	}
+	latest, err := NotifyDurable(ctx, conn, identity, "import.progress", "100%", NotifyDurableOpts{CollapseKey: key})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := UnseenNotifications(ctx, conn, identity, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 live row after collapse, got %d: %+v", len(got), got)
+	}
+	if got[0].ID != latest || got[0].Message != "100%" {
+		t.Fatalf("expected newest row (id=%d, msg=100%%), got %+v", latest, got[0])
+	}
+	if got[0].CollapseKey != key {
+		t.Fatalf("expected collapse key %q, got %q", key, got[0].CollapseKey)
+	}
+
+	// A different collapse key is an independent subject and is not collapsed.
+	if _, err := NotifyDurable(ctx, conn, identity, "export.progress", "10%", NotifyDurableOpts{CollapseKey: "export-1"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err = UnseenNotifications(ctx, conn, identity, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 live rows across two collapse keys, got %d", len(got))
+	}
+}
+
+// TestUnseenFiltersStale verifies that notifications past their relevance window
+// are filtered from the unseen read even though they still physically exist.
+// The expires_at > created_at constraint forbids inserting an already-stale row
+// through cb_notify_durable, so the stale row is seeded directly with a past
+// created_at.
+func TestUnseenFiltersStale(t *testing.T) {
+	client := getTestClient(t)
+	ctx := t.Context()
+	conn := client.Conn
+
+	identity := "TestUnseenFiltersStale"
+
+	seedStaleNotification(t, ctx, conn, identity, "stale")
+
+	// A fresh, still-relevant notification alongside it.
+	fresh, err := NotifyDurable(ctx, conn, identity, "fresh", "live", NotifyDurableOpts{ExpiresAt: time.Now().Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := UnseenNotifications(ctx, conn, identity, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != fresh {
+		t.Fatalf("expected only the fresh row, got %+v", got)
+	}
+
+	// The stale row is still physically present until GC.
+	if n := countNotifications(t, ctx, conn, identity); n != 2 {
+		t.Fatalf("expected 2 physical rows before GC, got %d", n)
+	}
+}
+
+// TestGCDeletesExpiredNotifications verifies that cb_gc physically deletes
+// notifications past their relevance window and reports the count. A notification
+// with no expiry (waits until seen) must survive GC.
+func TestGCDeletesExpiredNotifications(t *testing.T) {
+	client := getTestClient(t)
+	ctx := t.Context()
+	conn := client.Conn
+
+	identity := "TestGCDeletesExpiredNotifications"
+
+	seedStaleNotification(t, ctx, conn, identity, "stale")
+	// A notification with no expiry waits until seen and must survive GC.
+	keep, err := NotifyDurable(ctx, conn, identity, "keep", "waits until seen")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := GC(ctx, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.ExpiredNotificationsDeleted < 1 {
+		t.Fatalf("expected at least 1 expired notification deleted, got %d", info.ExpiredNotificationsDeleted)
+	}
+
+	if n := countNotifications(t, ctx, conn, identity); n != 1 {
+		t.Fatalf("expected 1 row remaining after GC, got %d", n)
+	}
+	got, err := UnseenNotifications(ctx, conn, identity, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != keep {
+		t.Fatalf("expected the no-expiry row to survive, got %+v", got)
+	}
+}
+
+// TestNotifyDurableConcurrentCursorOrdering verifies that concurrent inserts get
+// distinct, monotonically increasing cursor ids and read back in id order.
+func TestNotifyDurableConcurrentCursorOrdering(t *testing.T) {
+	client := getTestClient(t)
+	ctx := t.Context()
+	conn := client.Conn
+
+	identity := "TestNotifyDurableConcurrentCursorOrdering"
+	const n = 25
+
+	var wg sync.WaitGroup
+	ids := make([]int64, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ids[i], errs[i] = NotifyDurable(ctx, conn, identity, "evt", fmt.Sprintf("msg-%d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[int64]struct{}, n)
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("insert %d failed: %v", i, errs[i])
+		}
+		if _, dup := seen[ids[i]]; dup {
+			t.Fatalf("duplicate cursor id %d", ids[i])
+		}
+		seen[ids[i]] = struct{}{}
+	}
+
+	got, err := UnseenNotifications(ctx, conn, identity, 0, n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != n {
+		t.Fatalf("expected %d unseen, got %d", n, len(got))
+	}
+	if !sort.SliceIsSorted(got, func(a, b int) bool { return got[a].ID < got[b].ID }) {
+		t.Fatalf("unseen notifications not returned in cursor order")
+	}
+}
+
+// seedStaleNotification inserts an already-expired, unseen notification directly,
+// bypassing cb_notify_durable's expires_at > created_at constraint by backdating
+// created_at.
+func seedStaleNotification(t *testing.T, ctx context.Context, conn Conn, identity, message string) {
+	t.Helper()
+	_, err := conn.Exec(ctx,
+		`INSERT INTO cb_notifications (identity, topic, message, created_at, expires_at)
+		 VALUES ($1, 'stale.topic', $2, now() - interval '1 hour', now() - interval '1 minute')`,
+		identity, message)
+	if err != nil {
+		t.Fatalf("seeding stale notification: %v", err)
+	}
+}
+
+func countNotifications(t *testing.T, ctx context.Context, conn Conn, identity string) int {
+	t.Helper()
+	var n int
+	if err := conn.QueryRow(ctx, `SELECT count(*) FROM cb_notifications WHERE identity = $1`, identity).Scan(&n); err != nil {
+		t.Fatalf("counting notifications: %v", err)
+	}
+	return n
+}


### PR DESCRIPTION
Closes #29.

A durable, per-identity notification inbox: a mailbox keyed by `identity` with a monotonic cursor (`id`) and a `seen` marker. Unlike ephemeral Wire push (miss the moment, miss the message), the store is the cursor authority and clients catch up against it on their own schedule — "replay since I last looked" is just `WHERE id > cursor`. The inbox is a distinct primitive with **no dependency on Wire**.

## What's included

- **`migrations/00003_notifications.sql`** — logged `cb_notifications` table + unseen / `expires_at` / `collapse_key` indexes; `cb_notify_durable` (write-time keep-newest collapse, FCM `collapse_key` semantics — the deliberate opposite of the queue's keep-oldest `concurrency_key`) and `cb_mark_seen` (cursor ack); notification retention folded into the core `cb_gc` sweep. The `down` section restores the prior `cb_gc` and drops the table/functions.
- **`notifications.go`** — `Notification`, `NotifyDurableOpts`, `NotifyDurable`, `UnseenNotifications` (unseen *and* still-relevant), `MarkSeen`. `ExpiresAt` is optional: set it for a perishable relevance window, leave it zero to **wait until seen**. The trivial unseen read stays inlined in Go; mutations and retention stay in SQL.
- Client convenience methods; `ExpiredNotificationsDeleted` on `GCInfo`; `SchemaVersion` bumped to 3.
- Docs: README section + `docs/sql-api.md` entries and updated `cb_gc` shape.

## Tests

Append → unseen cursor paging → mark-seen-through; stale items filtered from the unseen read; expiry via `cb_gc`; keep-newest collapse by `collapse_key`; concurrent inserts preserve cursor ordering. Full suite green; migrate down/up round-trip verified.

## Deliberately out of scope

Seen-row retention when `ExpiresAt` is unset (a seen, no-expiry row is never GC'd) is a separate design decision and is **not** addressed here.