### PR TITLE
First-class polling transport + renderer generalization (Fragment / ServePoll)

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,9 +784,9 @@ wire.Listen("order.*", func(ctx context.Context, topic, message string) {
     log.Println(topic, message)
 })
 
-// RenderSSE: transform events for SSE clients (acts as allowlist)
-wire.RenderSSE("task.*.completed", func(r *http.Request, topic, message string) (catbird.SSEEvent, error) {
-    return catbird.SSEEvent{Event: "task-done", Data: "<div>Task done</div>"}, nil
+// Render: project events into a transport-neutral Fragment (acts as allowlist)
+wire.Render("task.*.completed", func(r *http.Request, topic, message string) (catbird.Fragment, error) {
+    return catbird.Fragment{Event: "task-done", Data: "<div>Task done</div>"}, nil
 })
 
 go wire.Start(ctx)
@@ -801,14 +801,16 @@ http.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
 })
 ```
 
-### Listen vs RenderSSE
+A `Render` definition is transport-neutral: `ServeSSE` wraps each `Fragment` as an SSE frame, and `ServePoll` concatenates fragments into an HTTP body backed by the [durable inbox](#durable-notifications) — define the projection once, pick the transport per surface. (`RenderSSE` is a deprecated alias for `Render`.)
+
+### Listen vs Render
 
 | Method | Runs on | Purpose |
 |--------|---------|---------|
 | `wire.Listen` | Every node | Server-side side effects (logging, webhooks) |
-| `wire.RenderSSE` | Node with SSE client | Transform for SSE push (e.g., JSON → HTML) |
+| `wire.Render` | Node serving SSE/poll | Project events into a `Fragment` (e.g., JSON → HTML) |
 
-Topics without a renderer pass through as-is. Multiple renderers matching the same topic each produce an SSE event. Render handlers receive the SSE client's `*http.Request` for access to user context (auth, language, etc).
+Topics without a renderer are handled per-transport: `ServeSSE` passes them through raw, `ServePoll` skips them. Multiple renderers matching the same topic each produce a fragment. Render handlers receive the client's `*http.Request` for access to user context (auth, language, etc).
 
 ### Notify
 
@@ -823,16 +825,16 @@ client.Notify(ctx, "order.created", `{"id": 123}`)
 wire.Notify(ctx, "order.created", `{"id": 123}`)
 ```
 
-### SSEEvent
+### Fragment
 
-`SSEEvent` controls the full SSE output: event name, data, and optional ID. It implements `io.Writer`, so templates can write directly to it:
+`Fragment` is the transport-neutral render output: a `Data` payload (e.g. an HTML fragment) plus SSE-only `Event`/`ID` hints. It implements `io.Writer`, so templates can write directly to it. `ServeSSE` frames it; `ServePoll` emits its `Data`. (`SSEEvent` is a deprecated alias for `Fragment`.)
 
 ```go
-// Typed helper — unmarshals JSON, gives full SSEEvent control
-catbird.RenderSSE[TaskEvent](wire, "task.*", func(r *http.Request, topic string, data TaskEvent) (catbird.SSEEvent, error) {
-    ev := catbird.SSEEvent{Event: "task-update", ID: topic}
-    err := views.TaskCompleted(r, data).Render(r.Context(), &ev)
-    return ev, err
+// Typed helper — unmarshals JSON, gives full Fragment control
+catbird.Render[TaskEvent](wire, "task.*", func(r *http.Request, topic string, data TaskEvent) (catbird.Fragment, error) {
+    f := catbird.Fragment{Event: "task-update", ID: topic}
+    err := views.TaskCompleted(r, data).Render(r.Context(), &f)
+    return f, err
 })
 ```
 
@@ -895,15 +897,16 @@ for _, n := range ns {
 }
 
 // Ack the cursor: mark everything up to an id seen (returns rows marked)
-marked, err := catbird.MarkSeen(ctx, conn, "user-123", ns[len(ns)-1].ID)
+marked, err := catbird.MarkSeenUntil(ctx, conn, "user-123", ns[len(ns)-1].ID)
 ```
 
 **Relevance window (`ExpiresAt`).** A notification is a *perishable pointer to a durable
 fact* — the underlying result lives permanently elsewhere (e.g. a task row); the
 notification is only the prompt to look. Set `ExpiresAt` to bound how long it is worth
 delivering: once it passes, the row drops out of `UnseenNotifications` and `cb_gc`
-deletes it. Leave it zero and the notification **waits until seen** (cleared by
-`MarkSeen`, not by a timer) — the right choice for "action required" items.
+deletes it. Leave it zero and the notification **waits until seen** (cleared by an
+explicit `MarkSeenUntil`/`MarkSeen` ack, not by a timer) — the right choice for
+"action required" items.
 
 ```go
 // Perishable toast: gone after an hour whether seen or not
@@ -930,6 +933,22 @@ notification twice:
 ```go
 catbird.NotifyDurable(ctx, conn, userID, topic, msg, opts) // the real message, stored
 wire.Notify(ctx, "user."+userID, "")                       // empty ping → client re-pulls
+```
+
+`wire.ServePoll` is the read side: it renders an identity's unseen notifications
+(scoped to the token's topics) through the **same `Render` definitions** as `ServeSSE`
+and returns them as one HTTP body, with the next cursor in the `X-Wire-Cursor` header.
+It is a pure read — the client acks explicitly, so opening the same surface in several
+tabs is convergent, not destructive:
+
+```go
+http.HandleFunc("/inbox", func(w http.ResponseWriter, r *http.Request) {
+    wire.ServePoll(w, r, r.URL.Query().Get("token")) // ?after=<cursor> for catch-up
+})
+
+// Ack on an explicit gesture, never on read:
+catbird.MarkSeenUntil(ctx, conn, userID, cursor)        // "mark all read" (bounded watermark)
+catbird.MarkSeen(ctx, conn, userID, []int64{id1, id2})  // dismiss specific items (precise)
 ```
 
 ## Naming Rules

--- a/catbird_test.go
+++ b/catbird_test.go
@@ -88,7 +88,7 @@ func verifyMigrationsApplied(ctx context.Context, db *sql.DB) error {
 		12: {"cb_next_cron_tick"},
 		13: {"cb_create_task_schedule", "cb_create_flow_schedule", "cb_advance_task_schedule", "cb_advance_flow_schedule", "cb_execute_due_task_schedules", "cb_execute_due_flow_schedules"},
 		16: {"cb_notify"},
-		3:  {"cb_notify_durable", "cb_mark_seen"},
+		3:  {"cb_notify_durable", "cb_mark_seen_until", "cb_mark_seen"},
 	}
 
 	for version, functions := range requiredFunctions {

--- a/client.go
+++ b/client.go
@@ -252,10 +252,17 @@ func (c *Client) UnseenNotifications(ctx context.Context, identity string, after
 	return UnseenNotifications(ctx, c.Conn, identity, afterID, limit)
 }
 
-// MarkSeen acks the cursor: marks all of identity's unseen notifications with id
-// less than or equal to upToID as seen, and returns the number of rows marked.
-func (c *Client) MarkSeen(ctx context.Context, identity string, upToID int64) (int64, error) {
-	return MarkSeen(ctx, c.Conn, identity, upToID)
+// MarkSeenUntil acks the cursor as a bounded watermark: marks all of identity's
+// unseen notifications with id less than or equal to id as seen, and returns the
+// number of rows marked. Whole-inbox scope only — see the package-level MarkSeenUntil.
+func (c *Client) MarkSeenUntil(ctx context.Context, identity string, id int64) (int64, error) {
+	return MarkSeenUntil(ctx, c.Conn, identity, id)
+}
+
+// MarkSeen acks precisely: marks the identity's unseen notifications whose id is in
+// ids as seen, and returns the number of rows marked. Use for subset-scoped acks.
+func (c *Client) MarkSeen(ctx context.Context, identity string, ids []int64) (int64, error) {
+	return MarkSeen(ctx, c.Conn, identity, ids)
 }
 
 // Reader continuously reads messages from a queue and processes them.

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -197,10 +197,16 @@ WHERE identity = 'user-123'
 ORDER BY id
 LIMIT 50;
 
--- Ack the cursor: mark everything up to an id seen; returns rows marked
+-- Ack as a bounded watermark: mark everything up to an id seen; returns rows marked
+SELECT cb_mark_seen_until(
+	identity => 'user-123',
+	id => 42
+);
+
+-- Ack precisely: mark only the named ids seen (subset-scoped); returns rows marked
 SELECT cb_mark_seen(
 	identity => 'user-123',
-	up_to_id => 42
+	ids => ARRAY[40, 42, 45]::bigint[]
 );
 ```
 
@@ -444,9 +450,14 @@ These are the functions most app code and external clients care about.
 - **Inputs**: `cb_notify_durable(identity text, topic text, message text DEFAULT NULL, collapse_key text DEFAULT NULL, expires_at timestamptz DEFAULT NULL)`
 - **Returns**: `RETURNS bigint`
 
+### `cb_mark_seen_until`
+- **What it does**: Bounded watermark ack: mark an identity's unseen notifications with `id <= id` as seen. Returns the number of rows marked. The `id` bound is load-bearing — it must not mark rows that arrived between a reader's fetch and its ack. Whole-inbox scope only; a by-`id` range is unsafe across interleaved subsets (use `cb_mark_seen` for subset-scoped acks).
+- **Inputs**: `cb_mark_seen_until(identity text, id bigint)`
+- **Returns**: `RETURNS bigint`
+
 ### `cb_mark_seen`
-- **What it does**: Cursor ack: mark an identity's unseen notifications with `id <= up_to_id` as seen. Returns the number of rows marked.
-- **Inputs**: `cb_mark_seen(identity text, up_to_id bigint)`
+- **What it does**: Precise ack: mark the identity's unseen notifications whose `id` is in `ids` as seen. Returns the number of rows marked. Used for subset-scoped acks — a transport matches a subset's unseen rows and acks exactly those ids, since subsets' ids interleave in one inbox and a range would clobber siblings.
+- **Inputs**: `cb_mark_seen(identity text, ids bigint[])`
 - **Returns**: `RETURNS bigint`
 
 The unseen read is a plain parameterized `SELECT` against `cb_notifications` (unseen **and** still-relevant: `seen_at IS NULL AND (expires_at IS NULL OR expires_at > now())`), not a function — see the usage example above.

--- a/migrations/00003_notifications.sql
+++ b/migrations/00003_notifications.sql
@@ -70,10 +70,37 @@ $$;
 -- +goose statementend
 
 -- +goose statementbegin
--- cb_mark_seen: cursor ack. Marks unseen rows with id <= up_to_id as seen for this
--- identity. Returns the number of rows marked. Seen-tracking always flows through this
--- cursor regardless of transport.
-CREATE OR REPLACE FUNCTION cb_mark_seen(identity text, up_to_id bigint)
+-- cb_mark_seen_until: bounded watermark ack. Marks an identity's unseen rows with
+-- id <= id as seen, and returns the number of rows marked. The id bound is
+-- load-bearing: it must not mark rows that arrived between a reader's fetch and its
+-- ack. Whole-inbox scope only — a by-id range is unsafe across interleaved subsets,
+-- so subset-scoped acks use cb_mark_seen(ids) instead. Seen-tracking always flows
+-- through these acks regardless of transport.
+CREATE OR REPLACE FUNCTION cb_mark_seen_until(identity text, id bigint)
+RETURNS bigint
+LANGUAGE plpgsql AS $$
+DECLARE
+    _marked bigint;
+BEGIN
+    UPDATE cb_notifications
+    SET seen_at = now()
+    WHERE cb_notifications.identity = cb_mark_seen_until.identity
+      AND cb_notifications.id <= cb_mark_seen_until.id
+      AND cb_notifications.seen_at IS NULL;
+
+    GET DIAGNOSTICS _marked = ROW_COUNT;
+
+    RETURN _marked;
+END;
+$$;
+-- +goose statementend
+
+-- +goose statementbegin
+-- cb_mark_seen: precise ack. Marks the identity's unseen rows whose id is in ids as
+-- seen, and returns the number of rows marked. Used for subset-scoped acks: a transport
+-- matches a subset's unseen rows and acks exactly those ids, since subsets' ids
+-- interleave in one inbox and a range (cb_mark_seen_until) would clobber siblings.
+CREATE OR REPLACE FUNCTION cb_mark_seen(identity text, ids bigint[])
 RETURNS bigint
 LANGUAGE plpgsql AS $$
 DECLARE
@@ -82,7 +109,7 @@ BEGIN
     UPDATE cb_notifications
     SET seen_at = now()
     WHERE cb_notifications.identity = cb_mark_seen.identity
-      AND cb_notifications.id <= cb_mark_seen.up_to_id
+      AND cb_notifications.id = ANY(cb_mark_seen.ids)
       AND cb_notifications.seen_at IS NULL;
 
     GET DIAGNOSTICS _marked = ROW_COUNT;
@@ -225,7 +252,8 @@ $$;
 
 -- +goose down
 
-DROP FUNCTION IF EXISTS cb_mark_seen(text, bigint);
+DROP FUNCTION IF EXISTS cb_mark_seen(text, bigint[]);
+DROP FUNCTION IF EXISTS cb_mark_seen_until(text, bigint);
 DROP FUNCTION IF EXISTS cb_notify_durable(text, text, text, text, timestamptz);
 
 -- Restore cb_gc without the durable-notifications retention sweep.

--- a/notifications.go
+++ b/notifications.go
@@ -89,14 +89,35 @@ func UnseenNotifications(ctx context.Context, conn Conn, identity string, afterI
 	return pgx.CollectRows(rows, scanCollectibleNotification)
 }
 
-// MarkSeen acks the cursor: it marks all of identity's unseen notifications with
-// id less than or equal to upToID as seen, and returns the number of rows marked.
-// Seen-tracking always flows through this cursor, regardless of transport.
-func MarkSeen(ctx context.Context, conn Conn, identity string, upToID int64) (int64, error) {
-	q := `SELECT cb_mark_seen(identity => $1, up_to_id => $2);`
+// MarkSeenUntil acks the cursor as a bounded watermark: it marks all of identity's
+// unseen notifications with id less than or equal to id as seen, and returns the
+// number of rows marked. The id bound is load-bearing — it must not mark rows that
+// arrived between a reader's fetch and its ack.
+//
+// This is whole-inbox scope only: a by-id range is unsafe across interleaved subsets
+// (a subset's ids interleave with others' in one inbox), so subset-scoped acks use
+// MarkSeen instead. Seen-tracking always flows through these acks, regardless of
+// transport.
+func MarkSeenUntil(ctx context.Context, conn Conn, identity string, id int64) (int64, error) {
+	q := `SELECT cb_mark_seen_until(identity => $1, id => $2);`
 
 	var marked int64
-	err := conn.QueryRow(ctx, q, identity, upToID).Scan(&marked)
+	err := conn.QueryRow(ctx, q, identity, id).Scan(&marked)
+	if err != nil {
+		return 0, err
+	}
+	return marked, nil
+}
+
+// MarkSeen acks precisely: it marks the identity's unseen notifications whose id is
+// in ids as seen, and returns the number of rows marked. Use this for subset-scoped
+// acks — a transport matches a subset's unseen rows and acks exactly those ids, since
+// the watermark MarkSeenUntil would clobber interleaved sibling subsets.
+func MarkSeen(ctx context.Context, conn Conn, identity string, ids []int64) (int64, error) {
+	q := `SELECT cb_mark_seen(identity => $1, ids => $2);`
+
+	var marked int64
+	err := conn.QueryRow(ctx, q, identity, ids).Scan(&marked)
 	if err != nil {
 		return 0, err
 	}

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -105,14 +105,14 @@ func TestUnseenNotificationsPaging(t *testing.T) {
 	}
 }
 
-// TestMarkSeen verifies the cursor ack: marking through a mid-inbox id leaves
-// only later rows unseen and reports the number of rows marked.
-func TestMarkSeen(t *testing.T) {
+// TestMarkSeenUntil verifies the bounded watermark ack: marking through a mid-inbox
+// id leaves only later rows unseen and reports the number of rows marked.
+func TestMarkSeenUntil(t *testing.T) {
 	client := getTestClient(t)
 	ctx := t.Context()
 	conn := client.Conn
 
-	identity := "TestMarkSeen"
+	identity := "TestMarkSeenUntil"
 	var ids []int64
 	for i := 0; i < 4; i++ {
 		id, err := NotifyDurable(ctx, conn, identity, "evt", fmt.Sprintf("msg-%d", i))
@@ -123,7 +123,7 @@ func TestMarkSeen(t *testing.T) {
 	}
 
 	// Mark seen through the second notification.
-	marked, err := MarkSeen(ctx, conn, identity, ids[1])
+	marked, err := MarkSeenUntil(ctx, conn, identity, ids[1])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,12 +140,57 @@ func TestMarkSeen(t *testing.T) {
 	}
 
 	// Re-acking the same cursor is a no-op (rows already seen).
-	marked, err = MarkSeen(ctx, conn, identity, ids[1])
+	marked, err = MarkSeenUntil(ctx, conn, identity, ids[1])
 	if err != nil {
 		t.Fatal(err)
 	}
 	if marked != 0 {
 		t.Fatalf("expected 0 rows marked on re-ack, got %d", marked)
+	}
+}
+
+// TestMarkSeen verifies the precise ack: only the explicitly named ids are marked,
+// leaving interleaved siblings untouched (the subset-scoped ack semantics a watermark
+// can't express).
+func TestMarkSeen(t *testing.T) {
+	client := getTestClient(t)
+	ctx := t.Context()
+	conn := client.Conn
+
+	identity := "TestMarkSeen"
+	var ids []int64
+	for i := 0; i < 5; i++ {
+		id, err := NotifyDurable(ctx, conn, identity, "evt", fmt.Sprintf("msg-%d", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+
+	// Ack a non-contiguous subset, skipping interleaved siblings.
+	marked, err := MarkSeen(ctx, conn, identity, []int64{ids[0], ids[2], ids[4]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if marked != 3 {
+		t.Fatalf("expected 3 rows marked, got %d", marked)
+	}
+
+	got, err := UnseenNotifications(ctx, conn, identity, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].ID != ids[1] || got[1].ID != ids[3] {
+		t.Fatalf("expected only ids[1] and ids[3] unseen, got %+v", got)
+	}
+
+	// Re-acking already-seen ids is a no-op; only the still-unseen id counts.
+	marked, err = MarkSeen(ctx, conn, identity, []int64{ids[0], ids[1]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if marked != 1 {
+		t.Fatalf("expected 1 row marked on partial re-ack, got %d", marked)
 	}
 }
 

--- a/wire.go
+++ b/wire.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -20,31 +21,39 @@ const (
 	wireChannelSize         = 64
 	wireSlowConsumerTimeout = 5 * time.Second
 	wireHeartbeatInterval   = 5 * time.Second
+	wirePollDefaultLimit    = 100
+	wirePollMaxLimit        = 1000
 )
 
 // ListenHandler is called when a notification matches a registered pattern.
 // Handlers run synchronously in the dispatch goroutine — don't block.
 type ListenHandler = func(ctx context.Context, topic, message string)
 
-// SSEEvent represents a fully rendered SSE event ready for client delivery.
-type SSEEvent struct {
-	Event string // SSE event name; empty = use original topic
-	Data  string // SSE data field
-	ID    string // SSE id field; empty = omit
+// Fragment is a rendered projection of a (topic, message) for client delivery. Data is
+// the transport-neutral substance (e.g. an HTML fragment): ServePoll emits it directly,
+// ServeSSE puts it in data:, an HTMX-WebSocket transport would send it as the frame.
+// Event and ID are SSE-native framing hints — SSE uses them for event:/id:, poll and
+// HTMX-WebSocket ignore them, and a JSON-WebSocket or Web Push transport would re-encode
+// them (message type / dedup tag). Structured push notifications are otherwise a
+// different projection and aren't modeled here.
+type Fragment struct {
+	Event string // SSE event name (event:); defaults to the topic. Ignored by poll and HTMX-WebSocket.
+	Data  string // rendered content (e.g. an HTML fragment) — the transport-neutral substance
+	ID    string // SSE id (id:); optional dedup/identity hint. Informational (no Last-Event-ID replay).
 }
 
 // Write implements io.Writer, appending p to the Data field.
-// This allows SSEEvent to be used as a target for io.WriterTo (e.g. Templ components).
-func (e *SSEEvent) Write(p []byte) (int, error) {
-	e.Data += string(p)
+// This allows Fragment to be used as a target for io.WriterTo (e.g. Templ components).
+func (f *Fragment) Write(p []byte) (int, error) {
+	f.Data += string(p)
 	return len(p), nil
 }
 
-// SSERenderHandler transforms a Wire event into an SSE event for client delivery.
-// It receives the SSE client's HTTP request for access to user context
-// (auth, language, etc). Only topics with a registered renderer are
-// delivered to SSE clients — the renderer acts as an allowlist.
-type SSERenderHandler = func(r *http.Request, topic, message string) (SSEEvent, error)
+// RenderHandler projects a Wire event into a transport-neutral Fragment for client
+// delivery. It receives the client's HTTP request for access to user context
+// (auth, language, etc). Only topics with a registered renderer are delivered —
+// the renderer acts as an allowlist.
+type RenderHandler = func(r *http.Request, topic, message string) (Fragment, error)
 
 // Wire is a real-time pub/sub layer with SSE support and presence tracking.
 // It absorbs Listener's topic-matched dispatch, adds local delivery to
@@ -57,10 +66,10 @@ type Wire struct {
 	logger *slog.Logger
 	schema string
 
-	mu           sync.RWMutex
-	topics       *topicTrie[*wireSubscriber]
-	listeners    *topicTrie[ListenHandler]
-	sseRenderers *topicTrie[SSERenderHandler]
+	mu        sync.RWMutex
+	topics    *topicTrie[*wireSubscriber]
+	listeners *topicTrie[ListenHandler]
+	renderers *topicTrie[RenderHandler]
 }
 
 type wireSubscriber struct {
@@ -93,13 +102,13 @@ func NewWire(pool *pgxpool.Pool, secret []byte) *Wire {
 		panic("catbird: Wire secret must be exactly 32 bytes")
 	}
 	return &Wire{
-		id:           uuid.NewString(),
-		pool:         pool,
-		secret:       secret,
-		logger:       slog.Default(),
-		topics:       newTopicTrie[*wireSubscriber](),
-		listeners:    newTopicTrie[ListenHandler](),
-		sseRenderers: newTopicTrie[SSERenderHandler](),
+		id:        uuid.NewString(),
+		pool:      pool,
+		secret:    secret,
+		logger:    slog.Default(),
+		topics:    newTopicTrie[*wireSubscriber](),
+		listeners: newTopicTrie[ListenHandler](),
+		renderers: newTopicTrie[RenderHandler](),
 	}
 }
 
@@ -120,12 +129,14 @@ func (w *Wire) Listen(pattern string, fn ListenHandler) *Wire {
 	return w
 }
 
-// RenderSSE registers an SSE render handler for the given topic pattern.
-// Multiple renderers matching the same topic each produce an SSE event.
-// Topics without a renderer pass through as-is.
+// Render registers a render handler for the given topic pattern. The handler
+// projects a matching (topic, message) into a transport-neutral Fragment.
+// Multiple renderers matching the same topic each produce a fragment.
+// Topics without a renderer are handled per-transport: ServeSSE passes them
+// through raw, ServePoll skips them.
 // Must be called before Start.
-func (w *Wire) RenderSSE(pattern string, fn SSERenderHandler) *Wire {
-	w.sseRenderers.add(pattern, fn)
+func (w *Wire) Render(pattern string, fn RenderHandler) *Wire {
+	w.renderers.add(pattern, fn)
 	return w
 }
 
@@ -210,17 +221,86 @@ func (w *Wire) ServeSSE(rw http.ResponseWriter, r *http.Request, token string) {
 			sub.lastDelivery = time.Now()
 			sub.mu.Unlock()
 
-			events := w.renderSSE(sub.request, ev)
-			for _, sse := range events {
-				writeSSEEvent(rw, sse)
+			fragments := w.render(sub.request, ev)
+			if fragments == nil {
+				// No renderer for this topic: SSE passes the raw event through.
+				fragments = []Fragment{{Event: ev.topic, Data: ev.message}}
 			}
-			if len(events) > 0 {
+			for _, f := range fragments {
+				writeSSEEvent(rw, f)
+			}
+			if len(fragments) > 0 {
 				flusher.Flush()
 			}
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+// ServePoll serves the durable inbox as an HTTP poll surface for the given token —
+// the sibling transport to ServeSSE, sharing the same renderers. It renders the
+// identity's unseen notifications (scoped to the token's topics) into a single HTTP
+// body and is a pure read: it never acks. Seen-tracking flows through the explicit
+// MarkSeenUntil/MarkSeen primitives, so opening the same surface in multiple tabs is
+// idempotent and convergent.
+//
+// The cursor is the "after" query param (0 = from the start); the optional "limit"
+// param caps the page. The new cursor (the max id fetched) is returned in the
+// X-Wire-Cursor response header for the client's next poll. Topics without a renderer
+// are skipped (renderer-as-allowlist). Invalid or expired tokens yield 401; a token
+// without an identity yields 400 (the inbox is identity-keyed).
+func (w *Wire) ServePoll(rw http.ResponseWriter, r *http.Request, token string) {
+	payload, err := w.verifyToken(token)
+	if err != nil {
+		http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if payload.Identity == "" {
+		http.Error(rw, "Poll requires an identity token", http.StatusBadRequest)
+		return
+	}
+
+	after, _ := strconv.ParseInt(r.URL.Query().Get("after"), 10, 64)
+
+	limit := wirePollDefaultLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = min(n, wirePollMaxLimit)
+		}
+	}
+
+	rows, err := UnseenNotifications(r.Context(), w.pool, payload.Identity, after, limit)
+	if err != nil {
+		w.logger.WarnContext(r.Context(), "wire: poll read failed", "error", err)
+		http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	var body strings.Builder
+	cursor := after
+	for _, n := range rows {
+		// Advance the cursor past every fetched row, even ones this poller skips:
+		// the cursor is a per-poller delivery high-water mark (seen-state is separate),
+		// and ids are monotonic, so skipping out-of-scope rows never hides future
+		// in-scope ones.
+		if n.ID > cursor {
+			cursor = n.ID
+		}
+		// Scope to the token's granted topics — the inbox is identity-keyed, so a
+		// poller only sees the subset its token covers (the SSE per-topic equivalent).
+		if !payload.coversTopic(n.Topic) {
+			continue
+		}
+		for _, f := range w.render(r, wireEvent{topic: n.Topic, message: n.Message}) {
+			body.WriteString(f.Data)
+		}
+	}
+
+	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+	rw.Header().Set("Cache-Control", "no-cache")
+	rw.Header().Set("X-Wire-Cursor", strconv.FormatInt(cursor, 10))
+	_, _ = io.WriteString(rw, body.String())
 }
 
 // Presence returns the distinct identities connected to a topic across all nodes.
@@ -250,9 +330,9 @@ func (w *Wire) Notify(ctx context.Context, topic, message string) error {
 
 // --- Internal methods ---
 
-// writeSSEEvent writes a single SSE event to w. Multi-line data is split
-// into separate "data:" fields per the SSE spec.
-func writeSSEEvent(w io.Writer, ev SSEEvent) {
+// writeSSEEvent writes a single fragment as an SSE frame to w. Multi-line data is
+// split into separate "data:" fields per the SSE spec.
+func writeSSEEvent(w io.Writer, ev Fragment) {
 	fmt.Fprintf(w, "event: %s\n", ev.Event)
 	if ev.Data == "" {
 		fmt.Fprint(w, "data:\n")
@@ -423,39 +503,40 @@ func (w *Wire) presenceLeave(sub *wireSubscriber) {
 	}
 }
 
-// renderSSE matches sseRenderers for the event's topic and calls each match.
-// No renderer match → pass through raw event as-is.
-func (w *Wire) renderSSE(r *http.Request, ev wireEvent) []SSEEvent {
+// render matches the renderers for the event's topic and calls each match,
+// returning the produced fragments. No renderer match returns nil — the
+// no-renderer fallback (pass through raw, or skip) is a per-transport decision.
+func (w *Wire) render(r *http.Request, ev wireEvent) []Fragment {
 	w.mu.RLock()
-	renderers := w.sseRenderers.match(ev.topic, nil)
+	fns := w.renderers.match(ev.topic, nil)
 	w.mu.RUnlock()
 
-	if len(renderers) == 0 {
-		return []SSEEvent{{Event: ev.topic, Data: ev.message}}
+	if len(fns) == 0 {
+		return nil
 	}
 
-	events := make([]SSEEvent, 0, len(renderers))
-	for _, fn := range renderers {
-		sse, err := fn(r, ev.topic, ev.message)
+	fragments := make([]Fragment, 0, len(fns))
+	for _, fn := range fns {
+		f, err := fn(r, ev.topic, ev.message)
 		if err != nil {
-			w.logger.Warn("wire: sse render error", "topic", ev.topic, "error", err)
+			w.logger.Warn("wire: render error", "topic", ev.topic, "error", err)
 			continue
 		}
-		if sse.Event == "" {
-			sse.Event = ev.topic
+		if f.Event == "" {
+			f.Event = ev.topic
 		}
-		events = append(events, sse)
+		fragments = append(fragments, f)
 	}
-	return events
+	return fragments
 }
 
-// RenderSSE registers a typed SSE render handler that unmarshals JSON messages
-// into type T and passes them to fn for full SSEEvent control.
-func RenderSSE[T any](w *Wire, pattern string, fn func(r *http.Request, topic string, data T) (SSEEvent, error)) {
-	w.RenderSSE(pattern, func(r *http.Request, topic, message string) (SSEEvent, error) {
+// Render registers a typed render handler that unmarshals JSON messages into type T
+// and passes them to fn for full Fragment control.
+func Render[T any](w *Wire, pattern string, fn func(r *http.Request, topic string, data T) (Fragment, error)) {
+	w.Render(pattern, func(r *http.Request, topic, message string) (Fragment, error) {
 		var data T
 		if err := json.Unmarshal([]byte(message), &data); err != nil {
-			return SSEEvent{}, err
+			return Fragment{}, err
 		}
 		return fn(r, topic, data)
 	})

--- a/wire_test.go
+++ b/wire_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -469,6 +470,101 @@ func TestWireNotifySSEWildcard(t *testing.T) {
 	}
 	if events[0].data != "finished" {
 		t.Errorf("data = %q, want %q", events[0].data, "finished")
+	}
+}
+
+func TestWireServePollUnauthorized(t *testing.T) {
+	getTestClient(t)
+	wire := NewWire(testPool, testSecret)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/poll", nil)
+	wire.ServePoll(rr, req, "bad-token")
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestWireServePollRequiresIdentity(t *testing.T) {
+	getTestClient(t)
+	wire := NewWire(testPool, testSecret)
+
+	// A token without an identity can't address the identity-keyed inbox.
+	token := wire.Token([]string{"notif.#"})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/poll", nil)
+	wire.ServePoll(rr, req, token)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+// TestWireServePoll exercises the poll transport end to end: the same Render
+// definition projects stored inbox rows, the token's topic scope filters the
+// identity-keyed inbox to a subset, the cursor advances past skipped rows, and the
+// poll is a pure read (no ack).
+func TestWireServePoll(t *testing.T) {
+	cb := getTestClient(t)
+	ctx := t.Context()
+	wire := NewWire(testPool, testSecret)
+
+	identity := "poll-user-" + uuid.NewString()[:8]
+	base := "notif." + uuid.NewString()[:8]
+	drawerTopic := base + ".message"
+	otherTopic := "change." + uuid.NewString()[:8] // out of the token's scope
+
+	// One renderer, shared by both transports: wrap the message in an <li>.
+	wire.Render(base+".#", func(r *http.Request, topic, message string) (Fragment, error) {
+		return Fragment{Data: "<li>" + message + "</li>"}, nil
+	})
+
+	// Seed the inbox: two in-scope rows interleaved with one out-of-scope row.
+	if _, err := cb.NotifyDurable(ctx, identity, drawerTopic, "one"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cb.NotifyDurable(ctx, identity, otherTopic, "ignored"); err != nil {
+		t.Fatal(err)
+	}
+	lastID, err := cb.NotifyDurable(ctx, identity, drawerTopic, "two")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Identity token scoped to the drawer subset only.
+	token := wire.Token([]string{base + ".#"}, TokenOpts{Identity: identity})
+
+	rr := httptest.NewRecorder()
+	wire.ServePoll(rr, httptest.NewRequest("GET", "/poll?after=0", nil), token)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	// Only in-scope rows rendered, in cursor order; the out-of-scope row is skipped.
+	if got := rr.Body.String(); got != "<li>one</li><li>two</li>" {
+		t.Fatalf("body = %q", got)
+	}
+	// Cursor advances past every fetched row, including the skipped one.
+	if got := rr.Header().Get("X-Wire-Cursor"); got != strconv.FormatInt(lastID, 10) {
+		t.Fatalf("cursor = %q, want %d", got, lastID)
+	}
+
+	// Pure read: nothing was acked, so all three rows are still unseen.
+	unseen, err := UnseenNotifications(ctx, testPool, identity, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unseen) != 3 {
+		t.Fatalf("expected 3 rows still unseen (poll must not ack), got %d", len(unseen))
+	}
+
+	// Polling again from the returned cursor is caught up: empty body.
+	rr2 := httptest.NewRecorder()
+	wire.ServePoll(rr2, httptest.NewRequest("GET", "/poll?after="+strconv.FormatInt(lastID, 10), nil), token)
+	if rr2.Body.Len() != 0 {
+		t.Fatalf("expected empty body on caught-up poll, got %q", rr2.Body.String())
 	}
 }
 

--- a/wire_token.go
+++ b/wire_token.go
@@ -24,6 +24,17 @@ type tokenPayload struct {
 	Expiry   int64    `json:"e,omitempty"`
 }
 
+// coversTopic reports whether any of the token's granted topic patterns matches the
+// concrete topic. Used by ServePoll to scope an identity's inbox to the token's reach.
+func (p *tokenPayload) coversTopic(topic string) bool {
+	for _, pattern := range p.Topics {
+		if matchTopic(pattern, topic) {
+			return true
+		}
+	}
+	return false
+}
+
 // Token mints a signed, URL-safe SSE connection token for the given topics.
 // The token is encrypted with AES-256-GCM and encoded as base64url (no padding).
 // Panics if the secret is invalid or the system's random source fails.


### PR DESCRIPTION
Generalizes Wire's SSE-specific renderer into a transport-neutral projection and adds `ServePoll`, an HTTP poll surface over the durable inbox that shares one renderer definition with SSE. Design discussion and prior-art rationale are in #40.

## Wire renderer (clean break — 0.x, no deprecation aliases)
- `SSEEvent` → `Fragment`, `SSERenderHandler` → `RenderHandler`, `RenderSSE`/`RenderSSE[T]` → `Render`/`Render[T]`, field `sseRenderers` → `renderers`, method `renderSSE` → `render`.
- `render` returns matched fragments only; the no-renderer fallback is now a **per-transport** choice — `ServeSSE` passes the raw event through (preserving today's behavior), `ServePoll` skips renderer-less topics.
- `Fragment` keeps an SSE-honest shape: `Data` is the transport-neutral substance; `Event`/`ID` are SSE-native framing hints (poll ignores them).

## `ServePoll`
Token → identity, read `UnseenNotifications`, filter by the token's topic scope **in Go** (SQL stays topic-opaque), render through the shared registry, concatenate into an HTTP body, return the next cursor in `X-Wire-Cursor`. A **pure read** — it never acks, so opening the same surface in multiple tabs is convergent, not destructive.

## Inbox ack primitives (`seen_at`, account-global per identity)
- Rename the watermark `MarkSeen(identity, upToID)` → `MarkSeenUntil(identity, id)` — whole-inbox scope only.
- Add precise `MarkSeen(identity, ids)` for subset-scoped acks (a by-id range would clobber interleaved sibling subsets).
- Migration `00003` edited in place (unreleased): `cb_mark_seen` → `cb_mark_seen_until(identity, id)`; new `cb_mark_seen(identity, ids bigint[])`.

## Docs & tests
- README and `docs/sql-api.md` updated.
- New `TestWireServePoll` (+ unauthorized/identity-required) and `TestMarkSeen` (precise); `TestMarkSeen` → `TestMarkSeenUntil` for the watermark. Full `./scripts/test.sh` green, including the down/up migration test.

## Consumer
raven adoption (the `RenderSSE`→`Render`, `SSEEvent`→`Fragment` rename) is tracked in ugent-library/raven#13, to land once this ships a release.

Closes #40
