### PR TITLE
fix(readme): add context parameter in OutputAs function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ flow.OnFail(func(ctx context.Context, order Order, failure catbird.FlowFailure) 
     }
 
     var chargeResult ChargeResult
-    if err := failure.OutputAs("charge", &chargeResult); err == nil {
+    if err := failure.OutputAs(ctx, "charge", &chargeResult); err == nil {
         // access completed step output when available
     }
 


### PR DESCRIPTION
OutputAs has signature:

```go
func (f FlowFailure) OutputAs(ctx context.Context, step string, out any) error {
```

[source](https://github.com/ugent-library/catbird/blob/3ef8ec08a9c291cd51ef2c16d3293154192b2fda/flow.go#L183-L189)