### PR TITLE
feat: expose failed step dependency inputs in flow OnFail

### DIFF
--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -575,6 +575,11 @@ These are mostly used by Catbird workers and scheduler internals. Most users sho
 - **Inputs**: `cb_get_flow_step_output(flow_name text, run_id bigint, step_name text)`
 - **Returns**: `RETURNS jsonb`
 
+### `cb_get_flow_step_dependency_outputs`
+- **What it does**: Fetch the outputs a step's dependencies produced, in dependency (handler-argument) order, excluding `IgnoreOutput` dependencies. Backs `FlowFailure.FailedStepDependencyInputs`.
+- **Inputs**: `cb_get_flow_step_dependency_outputs(flow_name text, run_id bigint, step_name text)`
+- **Returns**: `RETURNS TABLE(dependency_step_name text, output jsonb)`
+
 ### `cb_get_flow_step_status`
 - **What it does**: Read status details for a single step run.
 - **Inputs**: `cb_get_flow_step_status(flow_name text, run_id bigint, step_name text)`

--- a/flow.go
+++ b/flow.go
@@ -188,11 +188,71 @@ func (f FlowFailure) OutputAs(ctx context.Context, step string, out any) error {
 	return json.Unmarshal(b, out)
 }
 
+// StepDependencyInput is a single input a step received from one of its
+// dependencies. Value is the raw output the dependency produced; decode it with
+// As.
+type StepDependencyInput struct {
+	Name  string          // the dependency step's name
+	Value json.RawMessage // the output that dependency produced
+}
+
+// As decodes the dependency input into out.
+func (d StepDependencyInput) As(out any) error {
+	return json.Unmarshal(d.Value, out)
+}
+
+// FailedStepInputAs decodes the input that caused the failed step, into out.
+//
+// The meaning depends on the step type:
+//   - Normal steps: the flow input (the step handler's first parameter). This
+//     is NOT the inputs the step received from its dependencies — use
+//     FailedStepDependencyInputs for those.
+//   - Map steps: the individual array item the failed map task was processing,
+//     not the whole flow input.
+//
+// It returns ErrNoFailedStepInput when no input was captured.
 func (f FlowFailure) FailedStepInputAs(out any) error {
 	if len(f.FailedStepInput) == 0 {
 		return ErrNoFailedStepInput
 	}
 	return json.Unmarshal(f.FailedStepInput, out)
+}
+
+// FailedStepDependencyInputs returns the inputs the failed step received from
+// its dependencies, in dependency (handler-argument) order. IgnoreOutput
+// dependencies are excluded, mirroring what the step handler actually received.
+//
+// It returns an empty slice for steps with no dependencies (for example a
+// flow's first step). Use this when you need the inputs a step received from
+// upstream steps — for example the doubled value a step failed on — rather than
+// the flow input returned by FailedStepInputAs.
+func (f FlowFailure) FailedStepDependencyInputs(ctx context.Context) ([]StepDependencyInput, error) {
+	if f.conn == nil {
+		return nil, ErrUnknownStepOutput
+	}
+
+	rows, err := f.conn.Query(
+		ctx,
+		`SELECT dependency_step_name, output FROM cb_get_flow_step_dependency_outputs($1, $2, $3)`,
+		f.FlowName, f.FlowRunID, f.FailedStepName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var deps []StepDependencyInput
+	for rows.Next() {
+		var dep StepDependencyInput
+		if err := rows.Scan(&dep.Name, &dep.Value); err != nil {
+			return nil, err
+		}
+		deps = append(deps, dep)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return deps, nil
 }
 
 func (f FlowFailure) FailedStepSignalAs(out any) error {

--- a/migrate.go
+++ b/migrate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-const SchemaVersion = 3
+const SchemaVersion = 4
 const gooseVersionTable = "cb_goose_db_version"
 
 //go:embed migrations/*.sql

--- a/migrations/00004_failed_step_dependencies.sql
+++ b/migrations/00004_failed_step_dependencies.sql
@@ -1,0 +1,51 @@
+-- +goose up
+
+-- cb_get_flow_step_dependency_outputs: Fetch the outputs a step consumed from its
+-- dependencies, in dependency (handler-argument) order. Backs
+-- FlowFailure.FailedStepDependencies so an on-fail handler can inspect the
+-- inputs a failed step received from upstream steps without re-encoding the DAG.
+--
+-- The step's dependency_step_names array is already ordered by declaration and
+-- excludes IgnoreOutput dependencies, so it mirrors the handler's parameter
+-- order. Each dependency's output is resolved via cb_get_flow_step_output, which
+-- aggregates mapper/generator outputs in item order.
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_get_flow_step_dependency_outputs(
+    flow_name text,
+    run_id bigint,
+    step_name text
+)
+RETURNS TABLE(dependency_step_name text, output jsonb)
+LANGUAGE plpgsql AS $$
+DECLARE
+    _s_table text := _cb_table_name(cb_get_flow_step_dependency_outputs.flow_name, 's');
+    _dep_names text[];
+BEGIN
+    EXECUTE format(
+        'SELECT dependency_step_names FROM %I WHERE flow_run_id = $1 AND step_name = $2',
+        _s_table
+    )
+    USING cb_get_flow_step_dependency_outputs.run_id, cb_get_flow_step_dependency_outputs.step_name
+    INTO _dep_names;
+
+    IF _dep_names IS NULL THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT dep.name,
+           cb_get_flow_step_output(
+               cb_get_flow_step_dependency_outputs.flow_name,
+               cb_get_flow_step_dependency_outputs.run_id,
+               dep.name
+           )
+    FROM unnest(_dep_names) WITH ORDINALITY AS dep(name, ord)
+    ORDER BY dep.ord;
+END;
+$$;
+-- +goose statementend
+
+-- +goose down
+
+DROP FUNCTION IF EXISTS cb_get_flow_step_dependency_outputs(text, bigint, text);

--- a/worker_test.go
+++ b/worker_test.go
@@ -620,6 +620,144 @@ func TestFlowOnFailMapStepInputIntegration(t *testing.T) {
 	}
 }
 
+func TestFlowOnFailStepDependenciesIntegration(t *testing.T) {
+	client := getTestClient(t)
+
+	onFailCalled := make(chan FlowFailure, 1)
+
+	flow := NewFlow("flow_on_fail_deps")
+	flow.AddStep(NewStep("double").Do(func(_ context.Context, input int) (int, error) {
+		return input * 2, nil
+	},
+		WithConcurrency(1),
+		WithBatchSize(10),
+	))
+	flow.AddStep(NewStep("add").
+		DependsOn("double").
+		Do(func(_ context.Context, _input int, _doubled int) (int, error) {
+			return 0, fmt.Errorf("add always fails")
+		},
+			WithConcurrency(1),
+			WithBatchSize(10),
+			WithMaxRetries(0),
+		))
+	flow.OnFail(func(_ context.Context, _input int, failure FlowFailure) error {
+		onFailCalled <- failure
+		return nil
+	},
+		WithConcurrency(1),
+		WithBatchSize(10),
+		WithMaxRetries(0),
+	)
+
+	worker := NewWorker(testPool).AddFlow(flow)
+	startTestWorker(t, worker)
+	time.Sleep(100 * time.Millisecond)
+
+	h, err := client.RunFlow(t.Context(), "flow_on_fail_deps", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var out int
+	if err := h.WaitForOutput(ctx, &out); err == nil {
+		t.Fatal("expected flow to fail")
+	}
+
+	select {
+	case f := <-onFailCalled:
+		if f.FailedStepName != "add" {
+			t.Fatalf("unexpected failed step name: %s", f.FailedStepName)
+		}
+
+		// FailedStepInputAs returns the flow input (10), not the dependency output.
+		var flowInput int
+		if err := f.FailedStepInputAs(&flowInput); err != nil {
+			t.Fatalf("expected failed step input to decode: %v", err)
+		}
+		if flowInput != 10 {
+			t.Fatalf("expected flow input 10, got %d", flowInput)
+		}
+
+		// FailedStepDependencyInputs returns the doubled value (20) the failed step consumed.
+		deps, err := f.FailedStepDependencyInputs(ctx)
+		if err != nil {
+			t.Fatalf("failed to get step dependency inputs: %v", err)
+		}
+		if len(deps) != 1 {
+			t.Fatalf("expected 1 dependency, got %d: %+v", len(deps), deps)
+		}
+		if deps[0].Name != "double" {
+			t.Fatalf("unexpected dependency name: %s", deps[0].Name)
+		}
+		var doubled int
+		if err := deps[0].As(&doubled); err != nil {
+			t.Fatalf("expected dependency output to decode: %v", err)
+		}
+		if doubled != 20 {
+			t.Fatalf("expected doubled value 20, got %d", doubled)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for flow on-fail handler")
+	}
+}
+
+func TestFlowOnFailStepDependenciesEmptyForRootStep(t *testing.T) {
+	client := getTestClient(t)
+
+	onFailCalled := make(chan FlowFailure, 1)
+
+	flow := NewFlow("flow_on_fail_deps_root")
+	flow.AddStep(NewStep("root").Do(func(_ context.Context, _input int) (int, error) {
+		return 0, fmt.Errorf("root always fails")
+	},
+		WithConcurrency(1),
+		WithBatchSize(10),
+		WithMaxRetries(0),
+	))
+	flow.OnFail(func(_ context.Context, _input int, failure FlowFailure) error {
+		onFailCalled <- failure
+		return nil
+	},
+		WithConcurrency(1),
+		WithBatchSize(10),
+		WithMaxRetries(0),
+	)
+
+	worker := NewWorker(testPool).AddFlow(flow)
+	startTestWorker(t, worker)
+	time.Sleep(100 * time.Millisecond)
+
+	h, err := client.RunFlow(t.Context(), "flow_on_fail_deps_root", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var out int
+	if err := h.WaitForOutput(ctx, &out); err == nil {
+		t.Fatal("expected flow to fail")
+	}
+
+	select {
+	case f := <-onFailCalled:
+		deps, err := f.FailedStepDependencyInputs(ctx)
+		if err != nil {
+			t.Fatalf("failed to get step dependency inputs: %v", err)
+		}
+		if len(deps) != 0 {
+			t.Fatalf("expected no dependency inputs for root step, got %+v", deps)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for flow on-fail handler")
+	}
+}
+
 func TestWorkerValidatesTaskHandlerOpts(t *testing.T) {
 	_ = getTestClient(t)
 


### PR DESCRIPTION
## What

Adds `FlowFailure.FailedStepDependencyInputs(ctx)` so a flow's `OnFail` handler can inspect the inputs a failed step received from its dependencies — in handler-argument order, excluding `IgnoreOutput` deps — **without re-encoding the DAG**.

### Motivation

Previously the only per-step datum in `OnFail` was `FailedStepInputAs`, which returns the *flow input* (or the failed item for map steps) — not the dependency outputs the step actually consumed. To get the latter you had to read `FailedStepName`, know which steps it depended on, and call `OutputAs` for each. This closes that gap.

```go
flow.OnFail(func(ctx context.Context, _input int, failure catbird.FlowFailure) error {
    for _, in := range failure.FailedStepDependencyInputs(ctx) {
        fmt.Printf("%s produced: %s\n", in.Name, in.Value) // e.g. "double produced: 20"
        var v int
        in.As(&v)
    }
    return nil
})
```

## API

- `type StepDependencyInput struct { Name string; Value json.RawMessage }` with `As(out any) error`
- `func (f FlowFailure) FailedStepDependencyInputs(ctx context.Context) ([]StepDependencyInput, error)` — returns an empty slice for steps with no deps.
- Clarified `FailedStepInputAs` godoc to spell out what it does/doesn't return (flow input for normal steps; item for map steps; **not** dependency outputs).

## Engine

- New SQL helper `cb_get_flow_step_dependency_outputs(flow_name, run_id, step_name)` (schema **v4**). Reads the failed step's ordered `dependency_step_names` and resolves each output via the existing `cb_get_flow_step_output` (so mapper/generator aggregation isn't duplicated). Lazy/on-demand, consistent with `OutputAs` — not added to the `cb_claim_flow_on_fail` hot path.

## Notes

- Additive and backward-compatible — no existing API changed.
- Migration `00004` with matching down section; `SchemaVersion` bumped to 4.
- `docs/sql-api.md` updated.

## Tests

- `TestFlowOnFailStepDependenciesIntegration` — `double → add` flow; asserts `FailedStepInputAs` → flow input (10) and `FailedStepDependencyInputs` → `[{double, 20}]`.
- `TestFlowOnFailStepDependenciesEmptyForRootStep` — empty slice for a dependency-less step.
- Full suite green (incl. migration up/down verification).