### PR TITLE
fix: skip catch-up policy never enqueued a run

### DIFF
--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -635,12 +635,12 @@ These are mostly used by Catbird workers and scheduler internals. Most users sho
 - **Returns**: `RETURNS void`
 
 ### `cb_execute_due_task_schedules`
-- **What it does**: Execute due task schedules for selected task names in batches.
+- **What it does**: Execute due task schedules for selected task names in batches. Returns the number of runs enqueued. Under the `skip` policy a tick is suppressed only when it is genuinely stale (a later tick is already due, i.e. `cb_next_cron_tick(cron_spec, next_run_at) <= now()`); an on-time tick still enqueues under every policy. Suppressed ticks leave `last_run_at` / `last_enqueued_at` untouched.
 - **Inputs**: `cb_execute_due_task_schedules(task_names text[], batch_size int DEFAULT 32)`
 - **Returns**: `RETURNS int`
 
 ### `cb_execute_due_flow_schedules`
-- **What it does**: Execute due flow schedules for selected flow names in batches.
+- **What it does**: Execute due flow schedules for selected flow names in batches. Returns the number of runs enqueued. Under the `skip` policy a tick is suppressed only when it is genuinely stale (a later tick is already due, i.e. `cb_next_cron_tick(cron_spec, next_run_at) <= now()`); an on-time tick still enqueues under every policy. Suppressed ticks leave `last_run_at` / `last_enqueued_at` untouched.
 - **Inputs**: `cb_execute_due_flow_schedules(flow_names text[], batch_size int DEFAULT 32)`
 - **Returns**: `RETURNS int`
 

--- a/migrate.go
+++ b/migrate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-const SchemaVersion = 4
+const SchemaVersion = 5
 const gooseVersionTable = "cb_goose_db_version"
 
 //go:embed migrations/*.sql

--- a/migrations/00005_fix_skip_catchup.sql
+++ b/migrations/00005_fix_skip_catchup.sql
@@ -1,0 +1,231 @@
+-- +goose up
+
+-- cb_execute_due_task_schedules / cb_execute_due_flow_schedules previously
+-- routed *every* due tick under the 'skip' policy through the no-enqueue
+-- branch, so a schedule created with WithSkipCatchUp() never produced a run at
+-- all -- not just on downtime recovery, but during normal operation too.
+--
+-- The catch-up policy is only meant to govern how *missed* ticks are handled on
+-- recovery; an on-time tick must still enqueue under every policy. A tick is
+-- genuinely stale (missed) only when a later tick has already come due, i.e.
+-- cb_next_cron_tick(cron_spec, next_run_at) <= now(). Under 'skip' we suppress
+-- the run only in that case; on-time ticks fall through to the enqueue branch.
+--
+-- Because the skip advance jumps next_run_at straight past now() in a single
+-- step (GREATEST(next_run_at, now())), a multi-tick backlog only ever evaluates
+-- the oldest tick, so recovery from N missed ticks still enqueues 0 runs -- the
+-- documented behaviour. The stale-skip branch also no longer records a phantom
+-- run: last_run_at / last_enqueued_at are left untouched when nothing is
+-- enqueued (cb_advance_*_schedule set them unconditionally, masking the bug).
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_execute_due_task_schedules(task_names text[], batch_size int DEFAULT 32)
+RETURNS int
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_executed int := 0;
+    v_id bigint;
+    v_task_name text;
+    v_input jsonb;
+    v_scheduled_at timestamptz;
+    v_cron_spec text;
+    v_key text;
+    v_policy text;
+BEGIN
+    FOR i IN 1..cb_execute_due_task_schedules.batch_size LOOP
+        -- Claim one due schedule with FOR UPDATE SKIP LOCKED
+        SELECT s.id, s.task_name, s.input, s.next_run_at, s.cron_spec, s.catch_up
+        INTO v_id, v_task_name, v_input, v_scheduled_at, v_cron_spec, v_policy
+        FROM cb_task_schedules s
+        WHERE
+            s.enabled = true
+            AND s.next_run_at <= now()
+            AND s.task_name = ANY(cb_execute_due_task_schedules.task_names)
+        ORDER BY s.next_run_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED;
+
+        -- No more due schedules in this batch
+        EXIT WHEN v_id IS NULL;
+
+        IF v_policy = 'skip' AND cb_next_cron_tick(v_cron_spec, v_scheduled_at) <= now() THEN
+            -- Stale tick (a later tick is already due): skip the backlog and
+            -- jump to the future without enqueuing or recording a run.
+            UPDATE cb_task_schedules s
+            SET
+                next_run_at = cb_next_cron_tick(s.cron_spec, GREATEST(s.next_run_at, now())),
+                updated_at = now()
+            WHERE s.id = v_id;
+        ELSE
+            -- one / all / on-time skip: enqueue + advance (policy governs advance)
+            v_key := 'schedule:' || EXTRACT(EPOCH FROM v_scheduled_at)::text;
+            v_input := COALESCE(v_input, '{}'::jsonb);
+
+            PERFORM cb_run_task(v_task_name, v_input, v_key);
+            PERFORM cb_advance_task_schedule(v_id, v_policy);
+
+            v_executed := v_executed + 1;
+        END IF;
+    END LOOP;
+
+    RETURN v_executed;
+END;
+$$;
+-- +goose statementend
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_execute_due_flow_schedules(flow_names text[], batch_size int DEFAULT 32)
+RETURNS int
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_executed int := 0;
+    v_id bigint;
+    v_flow_name text;
+    v_input jsonb;
+    v_scheduled_at timestamptz;
+    v_cron_spec text;
+    v_key text;
+    v_policy text;
+BEGIN
+    FOR i IN 1..cb_execute_due_flow_schedules.batch_size LOOP
+        -- Claim one due schedule with FOR UPDATE SKIP LOCKED
+        SELECT s.id, s.flow_name, s.input, s.next_run_at, s.cron_spec, s.catch_up
+        INTO v_id, v_flow_name, v_input, v_scheduled_at, v_cron_spec, v_policy
+        FROM cb_flow_schedules s
+        WHERE
+            s.enabled = true
+            AND s.next_run_at <= now()
+            AND s.flow_name = ANY(cb_execute_due_flow_schedules.flow_names)
+        ORDER BY s.next_run_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED;
+
+        -- No more due schedules in this batch
+        EXIT WHEN v_id IS NULL;
+
+        IF v_policy = 'skip' AND cb_next_cron_tick(v_cron_spec, v_scheduled_at) <= now() THEN
+            -- Stale tick (a later tick is already due): skip the backlog and
+            -- jump to the future without enqueuing or recording a run.
+            UPDATE cb_flow_schedules s
+            SET
+                next_run_at = cb_next_cron_tick(s.cron_spec, GREATEST(s.next_run_at, now())),
+                updated_at = now()
+            WHERE s.id = v_id;
+        ELSE
+            -- one / all / on-time skip: enqueue + advance (policy governs advance)
+            v_key := 'schedule:' || EXTRACT(EPOCH FROM v_scheduled_at)::text;
+            v_input := COALESCE(v_input, '{}'::jsonb);
+
+            PERFORM cb_run_flow(v_flow_name, v_input, v_key);
+            PERFORM cb_advance_flow_schedule(v_id, v_policy);
+
+            v_executed := v_executed + 1;
+        END IF;
+    END LOOP;
+
+    RETURN v_executed;
+END;
+$$;
+-- +goose statementend
+
+-- +goose down
+
+-- Restore the pre-fix behaviour: skip always suppresses, advance always stamps.
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_execute_due_task_schedules(task_names text[], batch_size int DEFAULT 32)
+RETURNS int
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_executed int := 0;
+    v_id bigint;
+    v_task_name text;
+    v_input jsonb;
+    v_scheduled_at timestamptz;
+    v_key text;
+    v_policy text;
+BEGIN
+    FOR i IN 1..cb_execute_due_task_schedules.batch_size LOOP
+        -- Claim one due schedule with FOR UPDATE SKIP LOCKED
+        SELECT s.id, s.task_name, s.input, s.next_run_at, s.catch_up
+        INTO v_id, v_task_name, v_input, v_scheduled_at, v_policy
+        FROM cb_task_schedules s
+        WHERE
+            s.enabled = true
+            AND s.next_run_at <= now()
+            AND s.task_name = ANY(cb_execute_due_task_schedules.task_names)
+        ORDER BY s.next_run_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED;
+
+        -- No more due schedules in this batch
+        EXIT WHEN v_id IS NULL;
+
+        IF v_policy = 'skip' THEN
+            -- Skip: advance without enqueuing
+            PERFORM cb_advance_task_schedule(v_id, v_policy);
+        ELSE
+            -- one / all: enqueue + advance (difference is in advance function)
+            v_key := 'schedule:' || EXTRACT(EPOCH FROM v_scheduled_at)::text;
+            v_input := COALESCE(v_input, '{}'::jsonb);
+
+            PERFORM cb_run_task(v_task_name, v_input, v_key);
+            PERFORM cb_advance_task_schedule(v_id, v_policy);
+
+            v_executed := v_executed + 1;
+        END IF;
+    END LOOP;
+
+    RETURN v_executed;
+END;
+$$;
+-- +goose statementend
+
+-- +goose statementbegin
+CREATE OR REPLACE FUNCTION cb_execute_due_flow_schedules(flow_names text[], batch_size int DEFAULT 32)
+RETURNS int
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_executed int := 0;
+    v_id bigint;
+    v_flow_name text;
+    v_input jsonb;
+    v_scheduled_at timestamptz;
+    v_key text;
+    v_policy text;
+BEGIN
+    FOR i IN 1..cb_execute_due_flow_schedules.batch_size LOOP
+        -- Claim one due schedule with FOR UPDATE SKIP LOCKED
+        SELECT s.id, s.flow_name, s.input, s.next_run_at, s.catch_up
+        INTO v_id, v_flow_name, v_input, v_scheduled_at, v_policy
+        FROM cb_flow_schedules s
+        WHERE
+            s.enabled = true
+            AND s.next_run_at <= now()
+            AND s.flow_name = ANY(cb_execute_due_flow_schedules.flow_names)
+        ORDER BY s.next_run_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED;
+
+        -- No more due schedules in this batch
+        EXIT WHEN v_id IS NULL;
+
+        IF v_policy = 'skip' THEN
+            -- Skip: advance without enqueuing
+            PERFORM cb_advance_flow_schedule(v_id, v_policy);
+        ELSE
+            -- one / all: enqueue + advance (difference is in advance function)
+            v_key := 'schedule:' || EXTRACT(EPOCH FROM v_scheduled_at)::text;
+            v_input := COALESCE(v_input, '{}'::jsonb);
+
+            PERFORM cb_run_flow(v_flow_name, v_input, v_key);
+            PERFORM cb_advance_flow_schedule(v_id, v_policy);
+
+            v_executed := v_executed + 1;
+        END IF;
+    END LOOP;
+
+    RETURN v_executed;
+END;
+$$;
+-- +goose statementend

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -746,6 +746,74 @@ func TestSchedulerSkipPolicy(t *testing.T) {
 	if !nextRunAt.After(time.Now()) {
 		t.Fatalf("expected next_run_at in the future, got %s", nextRunAt.Format(time.RFC3339))
 	}
+
+	// A suppressed tick must not stamp a phantom run: last_run_at /
+	// last_enqueued_at stay NULL because nothing was enqueued.
+	var lastRunAt, lastEnqueuedAt *time.Time
+	if err := client.Conn.QueryRow(t.Context(),
+		`SELECT last_run_at, last_enqueued_at FROM cb_task_schedules WHERE task_name = $1`, taskName,
+	).Scan(&lastRunAt, &lastEnqueuedAt); err != nil {
+		t.Fatal(err)
+	}
+	if lastRunAt != nil {
+		t.Fatalf("expected last_run_at to stay NULL when skip suppressed a tick, got %s", lastRunAt)
+	}
+	if lastEnqueuedAt != nil {
+		t.Fatalf("expected last_enqueued_at to stay NULL when skip suppressed a tick, got %s", lastEnqueuedAt)
+	}
+}
+
+// TestSchedulerSkipPolicyOnTime verifies that with WithSkipCatchUp(), a tick
+// that just became due (no backlog) still enqueues a run. Regression test for
+// the bug where skip suppressed every tick, so the schedule never fired.
+func TestSchedulerSkipPolicyOnTime(t *testing.T) {
+	client := getTestClient(t)
+	suffix := fmt.Sprintf("_%d", time.Now().UnixNano())
+	taskName := "skip_ontime" + suffix
+
+	task := NewTask(taskName).Do(func(ctx context.Context, in string) (string, error) {
+		return "ok", nil
+	})
+
+	if err := CreateTask(t.Context(), client.Conn, task); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.CreateTaskSchedule(t.Context(), taskName, "* * * * *", WithSkipCatchUp()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate an on-time tick: due now, but the following tick is still in the
+	// future (start of the current minute), so it is not a missed/stale tick.
+	if _, err := client.Conn.Exec(t.Context(),
+		`UPDATE cb_task_schedules SET next_run_at = date_trunc('minute', now()) WHERE task_name = $1`,
+		taskName,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	var executed int
+	if err := client.Conn.QueryRow(t.Context(),
+		`SELECT cb_execute_due_task_schedules(ARRAY[$1]::text[], 32)`, taskName,
+	).Scan(&executed); err != nil {
+		t.Fatal(err)
+	}
+
+	// On-time skip tick: exactly 1 run enqueued.
+	if executed != 1 {
+		t.Fatalf("expected 1 run for on-time skip tick, got %d", executed)
+	}
+
+	// next_run_at advanced to the future.
+	var nextRunAt time.Time
+	if err := client.Conn.QueryRow(t.Context(),
+		`SELECT next_run_at FROM cb_task_schedules WHERE task_name = $1`, taskName,
+	).Scan(&nextRunAt); err != nil {
+		t.Fatal(err)
+	}
+	if !nextRunAt.After(time.Now()) {
+		t.Fatalf("expected next_run_at in the future, got %s", nextRunAt.Format(time.RFC3339))
+	}
 }
 
 // TestSchedulerAllPolicy verifies that with WithCatchUpAll(), 5 minutes of downtime
@@ -940,6 +1008,56 @@ func TestFlowSchedulerSkipPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if !nextRunAt.After(time.Now()) {
+		t.Fatalf("expected next_run_at in the future, got %s", nextRunAt.Format(time.RFC3339))
+	}
+}
+
+// TestFlowSchedulerSkipPolicyOnTime verifies that with WithSkipCatchUp(), an
+// on-time flow tick (no backlog) still enqueues a run.
+func TestFlowSchedulerSkipPolicyOnTime(t *testing.T) {
+	client := getTestClient(t)
+	suffix := fmt.Sprintf("_%d", time.Now().UnixNano())
+	flowName := "skip_flow_ontime" + suffix
+
+	flow := NewFlow(flowName)
+	flow.AddStep(NewStep("s1").Do(func(ctx context.Context, in string) (string, error) {
+		return "ok", nil
+	}))
+
+	if err := CreateFlow(t.Context(), client.Conn, flow); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.CreateFlowSchedule(t.Context(), flowName, "* * * * *", WithSkipCatchUp()); err != nil {
+		t.Fatal(err)
+	}
+
+	// On-time tick: due now, following tick still in the future.
+	if _, err := client.Conn.Exec(t.Context(),
+		`UPDATE cb_flow_schedules SET next_run_at = date_trunc('minute', now()) WHERE flow_name = $1`,
+		flowName,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	var executed int
+	if err := client.Conn.QueryRow(t.Context(),
+		`SELECT cb_execute_due_flow_schedules(ARRAY[$1]::text[], 32)`, flowName,
+	).Scan(&executed); err != nil {
+		t.Fatal(err)
+	}
+
+	if executed != 1 {
+		t.Fatalf("expected 1 run for on-time skip tick, got %d", executed)
+	}
+
+	var nextRunAt time.Time
+	if err := client.Conn.QueryRow(t.Context(),
+		`SELECT next_run_at FROM cb_flow_schedules WHERE flow_name = $1`, flowName,
+	).Scan(&nextRunAt); err != nil {
+		t.Fatal(err)
+	}
 	if !nextRunAt.After(time.Now()) {
 		t.Fatalf("expected next_run_at in the future, got %s", nextRunAt.Format(time.RFC3339))
 	}


### PR DESCRIPTION
## Problem

`WithSkipCatchUp()` prevented a schedule from **ever** enqueuing a run. The skip branch in `cb_execute_due_task_schedules` / `cb_execute_due_flow_schedules` routed *every* due tick through the no-enqueue path — not just missed/stale ticks on downtime recovery, but on-time ticks during normal operation. So the schedule advanced `next_run_at` every tick while the runs table stayed empty.

The catch-up policy is only meant to govern how *missed* ticks are handled on recovery; an on-time tick must still enqueue under every policy.

## Fix

Under `skip`, a tick is now suppressed only when it is **genuinely stale** — a later tick is already due, i.e. `cb_next_cron_tick(cron_spec, next_run_at) <= now()`. On-time ticks fall through to the enqueue branch.

Because the skip advance jumps `next_run_at` past `now()` in a single step (`GREATEST(next_run_at, now())`), a multi-tick backlog only ever evaluates its oldest tick, so recovery from N missed ticks still enqueues **0 runs** — the documented behaviour (README catch-up table and the existing `TestSchedulerSkipPolicy` stay green). This approach is grace-window-free and self-tunes to any cron spec.

Also fixes the secondary masking issue: the stale-skip path no longer stamps a phantom `last_run_at` / `last_enqueued_at` when nothing was enqueued.

The other secondary point in the issue (create silently ignoring `cron_spec`/`input`/`catch_up` changes) was already resolved in migration `00002` (#36) — no action needed.

## Changes

- **`migrations/00005_fix_skip_catchup.sql`** — redefines both `cb_execute_due_*_schedules`; down section restores the prior bodies.
- **`migrate.go`** — `SchemaVersion` 4 → 5.
- **`scheduler_test.go`** — new `TestSchedulerSkipPolicyOnTime` / `TestFlowSchedulerSkipPolicyOnTime`; extended `TestSchedulerSkipPolicy` to assert suppressed ticks leave `last_run_at`/`last_enqueued_at` NULL.
- **`docs/sql-api.md`** — documents the corrected skip semantics.

## Testing

Full suite passes (`go test .`, 52s). `TestForceMigrations` down→up roundtrip validates migration 00005 in both directions.

⚠️ **Schema change.** `SchemaVersion` is now 5. Run `cb migrate up` before deploying.

Closes #44
