### PR TITLE
Bound worker background polls with a deadline (#46)

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -17,6 +17,15 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// defaultPollTimeout bounds the periodic background queries a worker runs
+// (claim polls, hiding, heartbeat, schedule ticks, stop checks). It only
+// matters when a connection has stopped responding without failing — a
+// half-open socket where a read blocks forever and no error ever comes back.
+// Without it such a poll blocks its goroutine and leaks a pooled connection,
+// and nothing is ever logged; with it the poll returns an error, gets logged,
+// and the loop retries on a fresh connection.
+const defaultPollTimeout = 30 * time.Second
+
 type WorkerInfo struct {
 	ID              string             `json:"id"`
 	TaskHandlers    []*TaskHandlerInfo `json:"task_handlers"`
@@ -309,7 +318,10 @@ func (w *Worker) Start(ctx context.Context) error {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if _, err := w.pool.Exec(ctx, `SELECT * FROM cb_worker_heartbeat(id => $1);`, w.id); err != nil {
+				hbCtx, cancel := context.WithTimeout(ctx, defaultPollTimeout)
+				_, err := w.pool.Exec(hbCtx, `SELECT * FROM cb_worker_heartbeat(id => $1);`, w.id)
+				cancel()
+				if err != nil && ctx.Err() == nil {
 					w.logger.ErrorContext(ctx, "worker: cannot send heartbeat", "error", err)
 				}
 			}
@@ -334,26 +346,22 @@ func (w *Worker) Start(ctx context.Context) error {
 		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()
 
+		runDue := func(query, kind string) {
+			runCtx, cancel := context.WithTimeout(ctx, defaultPollTimeout)
+			defer cancel()
+			var count int
+			if err := w.pool.QueryRow(runCtx, query).Scan(&count); err != nil && ctx.Err() == nil {
+				w.logger.ErrorContext(ctx, "worker: cannot run due schedules", "kind", kind, "error", err)
+			}
+		}
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				// Poll for due task schedules and execute them
-				var taskCount int
-				if err := w.pool.QueryRow(ctx,
-					`SELECT cb_execute_due_task_schedules(array(SELECT task_name FROM cb_task_schedules WHERE enabled), 32)`,
-				).Scan(&taskCount); err != nil {
-					// Ignore errors - likely no schedules exist yet
-				}
-
-				// Poll for due flow schedules and execute them
-				var flowCount int
-				if err := w.pool.QueryRow(ctx,
-					`SELECT cb_execute_due_flow_schedules(array(SELECT flow_name FROM cb_flow_schedules WHERE enabled), 32)`,
-				).Scan(&flowCount); err != nil {
-					// Ignore errors - likely no schedules exist yet
-				}
+				runDue(`SELECT cb_execute_due_task_schedules(array(SELECT task_name FROM cb_task_schedules WHERE enabled), 32)`, "task")
+				runDue(`SELECT cb_execute_due_flow_schedules(array(SELECT flow_name FROM cb_flow_schedules WHERE enabled), 32)`, "flow")
 			}
 		}
 	})
@@ -1363,10 +1371,16 @@ type claimLoopConfig[C any] struct {
 	wakeup        <-chan struct{} // NOTIFY signal; nil = timer-only fallback
 	fallbackDelay time.Duration   // poll interval when no NOTIFY arrives (default 2s)
 	logPollError  func(context.Context, error)
+	pollTimeout   time.Duration // per-poll deadline; 0 = defaultPollTimeout
 }
 
 func runClaimLoop[C any](shutdownCtx, handlerCtx context.Context, wg *sync.WaitGroup, cfg claimLoopConfig[C]) {
 	claims := make(chan C)
+
+	timeout := cfg.pollTimeout
+	if timeout <= 0 {
+		timeout = defaultPollTimeout
+	}
 
 	wg.Go(func() {
 		defer close(claims)
@@ -1379,9 +1393,15 @@ func runClaimLoop[C any](shutdownCtx, handlerCtx context.Context, wg *sync.WaitG
 			default:
 			}
 
-			msgs, err := cfg.pollClaims(shutdownCtx)
+			pollCtx, cancel := context.WithTimeout(shutdownCtx, timeout)
+			msgs, err := cfg.pollClaims(pollCtx)
+			cancel()
 			if err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				// Only a shutdown of the whole worker ends the loop. A poll that
+				// hit the deadline above (or failed for any other reason) is a
+				// fault to log and retry on a fresh connection, not a reason to
+				// quit — checking the parent context tells the two apart.
+				if shutdownCtx.Err() != nil {
 					return
 				}
 
@@ -1673,7 +1693,14 @@ func isTaskCancelRequested(ctx context.Context, conn Conn, taskName string, runI
 }
 
 func isTaskCancelRequestedBestEffort(ctx context.Context, conn Conn, taskName string, runID int64) (bool, error) {
-	requested, err := isTaskCancelRequested(ctx, conn, taskName, runID)
+	primaryCtx := ctx
+	if ctx != nil {
+		var cancel context.CancelFunc
+		primaryCtx, cancel = context.WithTimeout(ctx, defaultPollTimeout)
+		defer cancel()
+	}
+
+	requested, err := isTaskCancelRequested(primaryCtx, conn, taskName, runID)
 	if err == nil || ctx == nil || ctx.Err() == nil {
 		return requested, err
 	}
@@ -1704,7 +1731,14 @@ func getFlowStatus(ctx context.Context, conn Conn, flowName string, runID int64)
 }
 
 func getFlowStatusBestEffort(ctx context.Context, conn Conn, flowName string, runID int64) (string, error) {
-	status, err := getFlowStatus(ctx, conn, flowName, runID)
+	primaryCtx := ctx
+	if ctx != nil {
+		var cancel context.CancelFunc
+		primaryCtx, cancel = context.WithTimeout(ctx, defaultPollTimeout)
+		defer cancel()
+	}
+
+	status, err := getFlowStatus(primaryCtx, conn, flowName, runID)
 	if err == nil || ctx == nil || ctx.Err() == nil {
 		return status, err
 	}
@@ -1941,7 +1975,9 @@ func startInFlightHider(handlerCtx context.Context, wg *sync.WaitGroup, interval
 			case <-handlerCtx.Done():
 				return
 			case <-ticker.C:
-				hideFn(handlerCtx)
+				hideCtx, cancel := context.WithTimeout(handlerCtx, defaultPollTimeout)
+				hideFn(hideCtx)
+				cancel()
 			}
 		}
 	})

--- a/worker_notifier.go
+++ b/worker_notifier.go
@@ -2,6 +2,7 @@ package catbird
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"sync"
@@ -69,6 +70,8 @@ type workerNotifier struct {
 	pool   *pgxpool.Pool
 	logger *slog.Logger
 
+	pollTimeout time.Duration // idle wait/ping deadline; 0 = defaultPollTimeout
+
 	mu   sync.Mutex
 	subs map[string][]*workerNotifyTarget // PG channel → list of targets
 }
@@ -135,6 +138,11 @@ func (n *workerNotifier) listenOnce(ctx context.Context, channels []string) erro
 
 	pgConn := conn.Conn()
 
+	timeout := n.pollTimeout
+	if timeout <= 0 {
+		timeout = defaultPollTimeout
+	}
+
 	for _, ch := range channels {
 		if _, listenErr := pgConn.Exec(ctx, "LISTEN "+pgx.Identifier{ch}.Sanitize()); listenErr != nil {
 			return listenErr
@@ -142,8 +150,24 @@ func (n *workerNotifier) listenOnce(ctx context.Context, channels []string) erro
 	}
 
 	for {
-		notification, waitErr := pgConn.WaitForNotification(ctx)
+		waitCtx, cancel := context.WithTimeout(ctx, timeout)
+		notification, waitErr := pgConn.WaitForNotification(waitCtx)
+		cancel()
 		if waitErr != nil {
+			// A clean timeout just means no notification arrived in this window — the
+			// connection may still be healthy. While the parent context is still live,
+			// ping to tell a quiet connection from one that has silently died: a healthy
+			// one keeps waiting, a dead one returns an error so listen() reconnects
+			// instead of blocking forever.
+			if errors.Is(waitErr, context.DeadlineExceeded) && ctx.Err() == nil {
+				pingCtx, pingCancel := context.WithTimeout(ctx, timeout)
+				pingErr := pgConn.Ping(pingCtx)
+				pingCancel()
+				if pingErr == nil {
+					continue
+				}
+				return pingErr
+			}
 			return waitErr
 		}
 

--- a/worker_resiliency_test.go
+++ b/worker_resiliency_test.go
@@ -1,0 +1,241 @@
+package catbird
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A poll that stops responding must surface as a logged error and the loop must
+// keep going, not park silently. The fake poll models pgx honoring the context
+// deadline: it blocks until either its context is cancelled (the deadline the
+// loop now sets) or the test lets it return, which is what pgx does once a
+// socket read deadline fires on a hung connection.
+func TestClaimLoopRecoversFromHungPoll(t *testing.T) {
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	defer shutdownCancel()
+	handlerCtx, handlerCancel := context.WithCancel(context.Background())
+	defer handlerCancel()
+
+	release := make(chan struct{})
+	var pollErrCount atomic.Int64
+	handled := make(chan int, 1)
+
+	cfg := claimLoopConfig[int]{
+		concurrency: 1,
+		pollTimeout: 100 * time.Millisecond,
+		pollClaims: func(ctx context.Context) ([]int, error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-release:
+				return []int{1}, nil
+			}
+		},
+		handleClaim: func(_ context.Context, msg int) {
+			select {
+			case handled <- msg:
+			default:
+			}
+		},
+		logPollError: func(_ context.Context, _ error) {
+			pollErrCount.Add(1)
+		},
+	}
+
+	var wg sync.WaitGroup
+	runClaimLoop(shutdownCtx, handlerCtx, &wg, cfg)
+
+	// The stuck poll must be logged, not swallowed by a parked goroutine.
+	deadline := time.After(2 * time.Second)
+	for pollErrCount.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("a stuck poll never surfaced an error; the loop parked silently")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Once the connection recovers, the same loop resumes claiming.
+	close(release)
+	select {
+	case <-handled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the loop did not resume claiming after the poll recovered")
+	}
+
+	shutdownCancel()
+	wg.Wait()
+}
+
+// Shutting the worker down mid-poll must end the loop quietly. A poll cancelled
+// by shutdown is not a fault and must not be logged as one — this is the case
+// the timeout fix must keep distinct from a poll that hit its own deadline.
+func TestClaimLoopShutdownExitsQuietly(t *testing.T) {
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	handlerCtx, handlerCancel := context.WithCancel(context.Background())
+	defer handlerCancel()
+
+	polling := make(chan struct{}, 1)
+	var pollErrCount atomic.Int64
+
+	cfg := claimLoopConfig[int]{
+		concurrency: 1,
+		pollTimeout: 5 * time.Second, // long, so shutdown wins the race, not the deadline
+		pollClaims: func(ctx context.Context) ([]int, error) {
+			select {
+			case polling <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		handleClaim: func(_ context.Context, _ int) {},
+		logPollError: func(_ context.Context, _ error) {
+			pollErrCount.Add(1)
+		},
+	}
+
+	var wg sync.WaitGroup
+	runClaimLoop(shutdownCtx, handlerCtx, &wg, cfg)
+
+	<-polling        // a poll is in flight
+	shutdownCancel() // shut down before the poll's own deadline
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the claim loop did not exit on shutdown")
+	}
+
+	if n := pollErrCount.Load(); n != 0 {
+		t.Fatalf("shutdown was logged as a poll error %d time(s); it should exit quietly", n)
+	}
+}
+
+// The NOTIFY listener waits with a deadline now, so a quiet connection hits that
+// deadline repeatedly. It must ping and keep listening across those idle
+// timeouts rather than tear down, and still deliver a notification afterwards.
+func TestWorkerNotifierSurvivesIdleTimeouts(t *testing.T) {
+	getTestClient(t) // initializes testPool
+
+	const idle = 200 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	n := newWorkerNotifier(testPool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	n.pollTimeout = idle
+	const channel = "cb_test_notifier_idle"
+	sig := make(chan struct{}, 1)
+	n.subscribe(channel, sig)
+
+	run, err := n.listen(ctx)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { run(); close(done) }()
+
+	// Stay idle well past several wait deadlines so the ping-based liveness
+	// check runs repeatedly.
+	time.Sleep(5 * idle)
+
+	if _, err := testPool.Exec(ctx, "SELECT pg_notify($1, $2)", channel, ""); err != nil {
+		t.Fatalf("pg_notify: %v", err)
+	}
+
+	select {
+	case <-sig:
+	case <-time.After(2 * time.Second):
+		t.Fatal("notification not delivered; the listener did not survive its idle timeouts")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not stop on shutdown")
+	}
+}
+
+// This drives the real thing the fix depends on: a genuine claim query, blocked
+// server-side (here by an ACCESS EXCLUSIVE lock, the issue's deterministic
+// stand-in for a stuck connection), must abort on its context deadline rather
+// than block forever, and must claim normally once the block clears. It is what
+// proves pgx turns the deadline into a real cancellation — the piece the
+// loop-level unit tests stub out.
+func TestClaimQueryAbortsOnDeadlineUnderLock(t *testing.T) {
+	client := getTestClient(t)
+	ctx := context.Background()
+
+	const flowName = "claim_deadline_flow"
+	flow := NewFlow(flowName)
+	flow.AddStep(NewStep("step1").Do(func(_ context.Context, in string) (string, error) {
+		return in, nil
+	}))
+	if err := client.CreateFlow(ctx, flow); err != nil {
+		t.Fatalf("create flow: %v", err)
+	}
+	// Enqueue a run but start no worker, so the root step sits queued and
+	// claimable.
+	if _, err := client.RunFlow(ctx, flowName, "input"); err != nil {
+		t.Fatalf("run flow: %v", err)
+	}
+
+	w := newStepWorker(testPool, slog.New(slog.NewTextHandler(io.Discard, nil)), flowName, flow.steps[0], nil, nil)
+	table := fmt.Sprintf("cb_s_%s", strings.ToLower(flowName))
+
+	// Block the step table so the claim query can make no progress.
+	lockTx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin lock tx: %v", err)
+	}
+	if _, err := lockTx.Exec(ctx, "LOCK TABLE "+table+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+		t.Fatalf("lock table: %v", err)
+	}
+	released := false
+	release := func() {
+		if !released {
+			released = true
+			_ = lockTx.Rollback(context.Background())
+		}
+	}
+	defer release()
+
+	// Under the lock the poll must hit its deadline, not hang.
+	pollCtx, pollCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	start := time.Now()
+	_, pollErr := w.pollClaims(pollCtx)
+	pollCancel()
+	elapsed := time.Since(start)
+
+	if !errors.Is(pollErr, context.DeadlineExceeded) {
+		t.Fatalf("blocked poll did not abort on the deadline: err=%v", pollErr)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("poll took %s; it hung rather than honoring the deadline", elapsed)
+	}
+
+	// Once the lock is gone, the same poll claims the queued step.
+	release()
+
+	recoverCtx, recoverCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer recoverCancel()
+	claims, err := w.pollClaims(recoverCtx)
+	if err != nil {
+		t.Fatalf("poll after lock released: %v", err)
+	}
+	if len(claims) == 0 {
+		t.Fatal("expected to claim the queued step after the lock was released")
+	}
+}


### PR DESCRIPTION
Fixes #46.

## Problem

A claim poll that never returns — a half-open socket left by the network after a brief blackout, where reads block forever and no error is ever raised — parked the poller goroutine for good. The step was never claimed again by that worker, nothing was logged, sibling loops kept running (so the worker looked healthy), and the checked-out pool connection leaked permanently. Only a process restart recovered it.

The retry/backoff path was already built and self-heals — but only for polls that *fail*. A hung connection produces neither a result nor an error, so it slipped past both the retry logic and the logging. The missing piece was a deadline.

## Fix

Every periodic background query a worker runs now uses a per-poll deadline (`defaultPollTimeout`, 30s):

- the five claim loops (task, step, map, task-on-fail, flow-on-fail),
- the in-flight hider (a hang here also caused duplicate execution),
- the heartbeat,
- the schedule ticks — which additionally **no longer swallow their query errors** (the worst blind spot: a stalled scheduler left no trace),
- the flow-stop / cancel checks,
- the NOTIFY listener.

A stuck query now returns an error, gets logged, and the loop retries on a fresh connection — routing into the error path that already self-heals.

Two subtleties worth calling out for review:

- **`runClaimLoop` loop-exit.** The old guard returned on *any* `context.DeadlineExceeded`, which would have silently killed the loop on a poll timeout exactly like the bug. It now keys the exit on `shutdownCtx.Err()`, so a poll that hits its own deadline is logged and retried, while only a real worker shutdown ends the loop.
- **NOTIFY listener.** `WaitForNotification` legitimately blocks indefinitely, so the deadline there is an idle checkpoint, not an abort: on a clean timeout it pings (also bounded) to tell a quiet connection from a dead one — a healthy one keeps waiting, a dead one reconnects.

Long-running work is unaffected: handler execution runs under the handler's own timeout, and the `cb_wait_*` client APIs run under the caller's context. This only bounds the worker's own plumbing.

No new public API. The timeout is an internal `const`; the claim loops and the notifier read it from an unexported struct field that defaults to the const, so tests can drive them faster.

## Tests

- `TestClaimLoopRecoversFromHungPoll` — a stuck poll is logged (not silently parked) and the loop resumes claiming.
- `TestClaimLoopShutdownExitsQuietly` — shutdown mid-poll exits without logging a spurious error (guards the loop-exit change).
- `TestClaimQueryAbortsOnDeadlineUnderLock` — a real claim query blocked by an `ACCESS EXCLUSIVE` lock aborts on its context deadline and claims the queued step once released. This exercises the real pgx + context + socket path — the premise the unit tests stub out.
- `TestWorkerNotifierSurvivesIdleTimeouts` — the listener survives repeated idle timeouts and still delivers.

The permanent half-open case (needs toxiproxy) stays a documented manual repro; a lock-blocked query exercises the same abort-and-recover path deterministically.

Full suite passes.